### PR TITLE
Mac and Linux language builds

### DIFF
--- a/.travis/before_deploy.sh
+++ b/.travis/before_deploy.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [ $TRAVIS_OS_NAME = linux ]; then
-    zip PokeFinder-linux.zip PokeFinder
+    zip PokeFinder-linux.zip PokeFinder languages
 else
-    /usr/local/Cellar/qt/5.9.1/bin/macdeployqt PokeFinder.app -dmg -verbose=2
-    mv PokeFinder.dmg PokeFinder-macOS.dmg
+    zip -r PokeFinder-macOS.zip PokeFinder.app languages
 fi

--- a/.travis/file.sh
+++ b/.travis/file.sh
@@ -3,5 +3,5 @@
 if [ $TRAVIS_OS_NAME = linux ]; then
     echo PokeFinder-linux.zip
 else
-    echo PokeFinder-macOS.dmg
+    echo PokeFinder-macOS.zip
 fi


### PR DESCRIPTION
## Feature

Mac and Linux builds can now include the ``languages`` folder in their zipped artifacts.

## Bug

Mac builds would not complete due to the CI not finding the binary needed for making a dmg.  The dmg also served little purpose, so the solution is to zip the final build.

## Changed

- Added the ``languages`` folder to the Linux artifact
- Added the ``languages`` folder to the Mac artifact
- Changed the Mac artifact to be a zip file