### PR TITLE
Advances research in Researcher + Fixes #65 and #123

### DIFF
--- a/Core/Gen3/Generators/WildGenerator3.cpp
+++ b/Core/Gen3/Generators/WildGenerator3.cpp
@@ -139,7 +139,10 @@ QVector<WildState> WildGenerator3::generate(u32 seed) const
         case Encounter::OldRod:
         case Encounter::GoodRod:
         case Encounter::SuperRod:
-            go.next();
+            if (!isSafariZoneEncounterArea())
+            {
+                go.next();
+            }
             state.setEncounterSlot(EncounterSlot::hSlot(go.nextUShort(), encounter));
             if (!filter.compareEncounterSlot(state))
             {
@@ -147,6 +150,10 @@ QVector<WildState> WildGenerator3::generate(u32 seed) const
             }
 
             state.setLevel(encounterArea.calcLevel(state.getEncounterSlot(), go.nextUShort()));
+            if (isSafariZoneEncounterArea())
+            {
+                go.next();
+            }
             break;
         default:
             break;
@@ -231,5 +238,5 @@ void WildGenerator3::setEncounterArea(const EncounterArea3 &encounterArea)
 
 bool WildGenerator3::isSafariZoneEncounterArea() const
 {
-    return encounterArea.getLocation() == 51 || encounterArea.getLocation() == 53;
+    return encounterArea.getLocation() == 49 || encounterArea.getLocation() == 50 || encounterArea.getLocation() == 51 || encounterArea.getLocation() == 52 || encounterArea.getLocation() == 53;
 }

--- a/Core/Gen3/Generators/WildGenerator3.cpp
+++ b/Core/Gen3/Generators/WildGenerator3.cpp
@@ -86,11 +86,18 @@ QVector<WildState> WildGenerator3::generate(u32 seed) const
         switch (encounter)
         {
         case Encounter::RockSmash:
-            if (!rock)
+            if (!isSafariZoneEncounterArea())
+            {
+                if (!rock)
+                {
+                    go.next();
+                }
+            }
+            else
             {
                 go.next();
             }
-            if (((go.nextUShort()) % 2880) >= rate)
+            if ((go.nextUShort() % 2880) >= rate)
             {
                 continue;
             }
@@ -102,6 +109,10 @@ QVector<WildState> WildGenerator3::generate(u32 seed) const
             }
 
             state.setLevel(encounterArea.calcLevel(state.getEncounterSlot(), go.nextUShort()));
+            if (isSafariZoneEncounterArea())
+            {
+                go.advance(1);
+            }
             break;
         case Encounter::SafariZone:
             state.setEncounterSlot(EncounterSlot::hSlot(go.nextUShort(), encounter));
@@ -216,4 +227,9 @@ QVector<WildState> WildGenerator3::generate(u32 seed) const
 void WildGenerator3::setEncounterArea(const EncounterArea3 &encounterArea)
 {
     this->encounterArea = encounterArea;
+}
+
+bool WildGenerator3::isSafariZoneEncounterArea() const
+{
+    return encounterArea.getLocation() == 51 || encounterArea.getLocation() == 53;
 }

--- a/Core/Gen3/Generators/WildGenerator3.hpp
+++ b/Core/Gen3/Generators/WildGenerator3.hpp
@@ -31,6 +31,7 @@ public:
     WildGenerator3(u32 initialAdvances, u32 maxAdvances, u16 tid, u16 sid, u8 genderRatio, Method method, const StateFilter &filter);
     QVector<WildState> generate(u32 seed) const;
     void setEncounterArea(const EncounterArea3 &encounterArea);
+    bool isSafariZoneEncounterArea() const;
 
 private:
     EncounterArea3 encounterArea;

--- a/Forms/Util/Researcher.cpp
+++ b/Forms/Util/Researcher.cpp
@@ -396,11 +396,18 @@ void Researcher::generate()
                           ui->comboBoxRValue10->currentText() };
 
     QVector<ResearcherState> states;
-    for (u32 cnt = 0; cnt < maxAdvances; cnt++)
+    for (u32 cnt = 0; cnt < maxAdvances + 1; cnt++)
     {
         ResearcherState state(rng64Bit, cnt + initialAdvances);
 
-        state.setState(rngStates.at(cnt));
+        if (cnt == 0)
+        {
+            state.setState(seed);
+        }
+        else
+        {
+            state.setState(rngStates.at(cnt - 1));
+        }
 
         for (u8 j = 0; j < 10; j++)
         {

--- a/Forms/Util/Researcher.cpp
+++ b/Forms/Util/Researcher.cpp
@@ -109,11 +109,24 @@ void Researcher::setupModels()
     connect(ui->pushButtonSearch, &QPushButton::clicked, this, &Researcher::search);
     connect(ui->pushButtonNext, &QPushButton::clicked, this, &Researcher::next);
     connect(ui->tableView, &QTableView::customContextMenuRequested, this, &Researcher::tableViewContextMenu);
+    connect(ui->comboBoxSearch, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index){ setuptextBoxSearchInputType(index); });
 
     QSettings setting;
     if (setting.contains("researcher/geometry"))
     {
         this->restoreGeometry(setting.value("researcher/geometry").toByteArray());
+    }
+}
+
+void Researcher::setuptextBoxSearchInputType(int index)
+{
+    if (index == 3)
+    {
+        ui->textBoxSearch->setValues(InputType::Advance64Bit);
+    }
+    else
+    {
+        ui->textBoxSearch->setValues(InputType::Seed64Bit);
     }
 }
 
@@ -438,7 +451,16 @@ void Researcher::search()
     }
 
     QString string = ui->comboBoxSearch->currentText();
-    u64 result = ui->textBoxSearch->text().toULongLong(nullptr, 16);
+    u64 result;
+
+    if (string == tr("Advances"))
+    {
+        result = ui->textBoxSearch->text().toULongLong(nullptr, 10);
+    }
+    else
+    {
+        result = ui->textBoxSearch->text().toULongLong(nullptr, 16);
+    }
 
     QModelIndex end = model->search(string, result, 0);
     if (end.isValid())
@@ -458,7 +480,7 @@ void Researcher::search()
 
 void Researcher::next()
 {
-    if (model->rowCount() == 0)
+    if (model->rowCount() == 0 || ui->comboBoxSearch->currentText() == tr("Advances"))
     {
         return;
     }

--- a/Forms/Util/Researcher.hpp
+++ b/Forms/Util/Researcher.hpp
@@ -47,6 +47,7 @@ private:
     QHash<QString, u8> keys;
 
     void setupModels();
+    void setuptextBoxSearchInputType(int);
     u64 getCustom(const QString &text, const ResearcherState &state, const QVector<ResearcherState> &states);
     void resizeHeader();
     QVector<bool> getHexCheck();

--- a/Forms/Util/Researcher.ui
+++ b/Forms/Util/Researcher.ui
@@ -2587,6 +2587,11 @@
           <string>16Bit Low</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>Advances</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="1" column="0" colspan="2">

--- a/Models/Util/ResearcherModel.cpp
+++ b/Models/Util/ResearcherModel.cpp
@@ -104,7 +104,12 @@ QModelIndex ResearcherModel::search(const QString &string, u64 result, int row)
 {
     int column = 0;
     std::function<u64(const ResearcherState &)> getResult;
-    if (string == tr("64Bit"))
+    if (string == tr("Advances"))
+    {
+        column = 0;
+        getResult = [](const ResearcherState &state) { return state.getAdvances(); };
+    }
+    else if (string == tr("64Bit"))
     {
         column = 1;
         getResult = [](const ResearcherState &state) { return state.getState(); };


### PR DESCRIPTION
* Fixed Rock Smash generation in Safari Zone for RSE (#65) - Tested and now working both inside and outside Safari Zone
* Fixed Fishing generation in Safari Zone for RSE (#65) - Tested and now working both inside and outside Safari Zone
* Added Advances research in Researcher window (useful for research purpose)
* Make Advances start from 1 (instead of 0) in Researcher window only (#123)