### PR TITLE
Use ISO 8601 format for dates

### DIFF
--- a/Source/Core/Util/DateTime.cpp
+++ b/Source/Core/Util/DateTime.cpp
@@ -107,7 +107,7 @@ std::string Date::toString() const
     std::string d = std::to_string(parts[2]);
     d.insert(d.begin(), 2 - d.size(), '0');
 
-    return m + "/" + d + "/" + y;
+    return y + "-" + m + "-" + d;
 }
 
 int Time::addSeconds(int seconds)

--- a/Source/Forms/Controls/DateEdit.cpp
+++ b/Source/Forms/Controls/DateEdit.cpp
@@ -21,6 +21,7 @@
 
 DateEdit::DateEdit(QWidget *parent) : QDateEdit(parent)
 {
+    setDisplayFormat("yyyy-MM-dd");
 }
 
 Date DateEdit::getDate() const

--- a/Source/Forms/Controls/DateTimeEdit.cpp
+++ b/Source/Forms/Controls/DateTimeEdit.cpp
@@ -21,7 +21,7 @@
 
 DateTimeEdit::DateTimeEdit(QWidget *parent) : QDateTimeEdit(parent)
 {
-    setDisplayFormat("yyyy-MM-dd HH:mm:ss");
+    setDisplayFormat("yyyy-MM-dd HH:mm");
 }
 
 DateTime DateTimeEdit::getDateTime() const

--- a/Source/Forms/Controls/DateTimeEdit.cpp
+++ b/Source/Forms/Controls/DateTimeEdit.cpp
@@ -21,6 +21,7 @@
 
 DateTimeEdit::DateTimeEdit(QWidget *parent) : QDateTimeEdit(parent)
 {
+    setDisplayFormat("yyyy-MM-dd  HH:mm:ss");
 }
 
 DateTime DateTimeEdit::getDateTime() const

--- a/Source/Forms/Controls/DateTimeEdit.cpp
+++ b/Source/Forms/Controls/DateTimeEdit.cpp
@@ -21,7 +21,7 @@
 
 DateTimeEdit::DateTimeEdit(QWidget *parent) : QDateTimeEdit(parent)
 {
-    setDisplayFormat("yyyy-MM-dd  HH:mm:ss");
+    setDisplayFormat("yyyy-MM-dd HH:mm:ss");
 }
 
 DateTime DateTimeEdit::getDateTime() const

--- a/Source/Forms/Gen3/IDs3.cpp
+++ b/Source/Forms/Gen3/IDs3.cpp
@@ -71,8 +71,6 @@ void IDs3::setupModels()
     ui->textBoxXDColoStartingAdvance->setValues(InputType::Advance32Bit);
     ui->textBoxXDColoMaxAdvances->setValues(InputType::Advance32Bit);
 
-    ui->dateTimeEdit->setDisplayFormat(QLocale::system().dateTimeFormat(QLocale::ShortFormat));
-
     connect(ui->pushButtonXDColoSearch, &QPushButton::clicked, this, &IDs3::xdColoSearch);
     connect(ui->pushButtonFRLGESearch, &QPushButton::clicked, this, &IDs3::frlgeSearch);
     connect(ui->pushButtonRSSearch, &QPushButton::clicked, this, &IDs3::rsSearch);

--- a/Source/Forms/Gen4/IDs4.ui
+++ b/Source/Forms/Gen4/IDs4.ui
@@ -373,7 +373,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDateTimeEdit" name="dateTimeEdit">
+       <widget class="DateTimeEdit" name="dateTimeEdit">
         <property name="maximumDate">
          <date>
           <year>2099</year>
@@ -449,6 +449,11 @@
    <class>TableView</class>
    <extends>QTableView</extends>
    <header>Forms/Controls/TableView.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>DateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>Forms/Controls/DateTimeEdit.hpp</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/Source/Forms/Gen5/Profile/ProfileCalibrator5.ui
+++ b/Source/Forms/Gen5/Profile/ProfileCalibrator5.ui
@@ -326,9 +326,6 @@
           <day>1</day>
          </datetime>
         </property>
-        <property name="displayFormat">
-         <string notr="true">MM/dd/yyyy HH:mm</string>
-        </property>
        </widget>
       </item>
       <item row="2" column="0" colspan="2">


### PR DESCRIPTION
In the USA, dates are often written as **month/day/year**. In many other countries, they are written as **day/month/year**. I believe that the second format is used for PAL region consoles. I propose using the ISO 8601 standard format for dates. This prints dates as **year-month-day**. For US region consoles, this will still be easy to understand since the year is the only 4 digit number and the order of month and day is preserved. For PAL region users, I believe my proposed format will be more understandable than the current default US format.

There might be 2 better alternatives:
- Representing the month as a 3 letter abbreviation. However in DS/3DS you enter the month as a number, so this will be slightly inconvenient, if less unambiguous.
- Adding a setting to decide the output format. But this would be out of the way in the dropdown menu.

Links:
- [ISO 8601 on Wikipedia](https://en.wikipedia.org/wiki/ISO_8601)
- [Date format by country on Wikipedia](https://en.wikipedia.org/wiki/Date_format_by_country)