### PR TITLE
Fix Gen 3 & 4 Egg IV generation

### DIFF
--- a/Source/Core/Gen3/Generators/EggGenerator3.cpp
+++ b/Source/Core/Gen3/Generators/EggGenerator3.cpp
@@ -46,7 +46,7 @@ void setInheritance(const Daycare &daycare, EggState3 &state, const u16 *inh, co
         state.setIVs(order[stat], daycare.getParentIV(parent, order[stat]));
         state.setInheritance(order[stat], parent + 1);
 
-        stat = available1[inh[2] % 4];
+        stat = available3[inh[2] % 4];
         parent = par[2] & 1;
         state.setIVs(order[stat], daycare.getParentIV(parent, order[stat]));
         state.setInheritance(order[stat], parent + 1);

--- a/Source/Core/Gen4/Generators/EggGenerator4.cpp
+++ b/Source/Core/Gen4/Generators/EggGenerator4.cpp
@@ -45,7 +45,7 @@ void setInheritance(const Daycare &daycare, EggState4 &state, const u16 *inh, co
         state.setIVs(order[stat], daycare.getParentIV(parent, order[stat]));
         state.setInheritance(order[stat], parent + 1);
 
-        stat = available1[inh[2] % 4];
+        stat = available3[inh[2] % 4];
         parent = par[2] & 1;
         state.setIVs(order[stat], daycare.getParentIV(parent, order[stat]));
         state.setInheritance(order[stat], parent + 1);


### PR DESCRIPTION
This change fixes the issue with IVs not generating correctly for Gen 3 & 4 eggs.

This should also fix issue #169 