### PR TITLE
Update Readme for building on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ MacOS
 Linux
 - Install the dependencies
   - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential qtbase5-dev qt5-qmake qt5-default qttools5-dev-tools
+  - sudo apt-get install -y build-essential qtbase5-dev qt5-qmake qt5-default qttools5-dev-tools qttools5-dev
 - Build
   - git submodule update
   - mkdir build


### PR DESCRIPTION
I added qttools5-dev as one of the packages needed to build PokeFinder on Linux. Without it, the following error occurs:

 Could not find a package configuration file provided by "Qt5LinguistTools"
  (requested version 5.5.1) with any of the following names:

    Qt5LinguistToolsConfig.cmake
    qt5linguisttools-config.cmake