### PR TITLE
[Gen 5] Fix Profile Manager

### DIFF
--- a/Source/Forms/Gen5/Stationary5.cpp
+++ b/Source/Forms/Gen5/Stationary5.cpp
@@ -130,6 +130,7 @@ void Stationary5::setupModels()
     connect(ui->pushButtonSearch, &QPushButton::clicked, this, &Stationary5::search);
     connect(ui->pushButtonGeneratorLead, &QPushButton::clicked, this, &Stationary5::generatorLead);
     connect(ui->pushButtonCalculateInitialAdvances, &QPushButton::clicked, this, &Stationary5::calculateInitialAdvances);
+    connect(ui->pushButtonProfileManager, &QPushButton::clicked, this, &Stationary5::profileManager);
     connect(ui->tableViewGenerator, &QTableView::customContextMenuRequested, this, &Stationary5::tableViewGeneratorContextMenu);
     connect(ui->tableViewSearcher, &QTableView::customContextMenuRequested, this, &Stationary5::tableViewSearcherContextMenu);
 

--- a/Source/Forms/MainWindow.cpp
+++ b/Source/Forms/MainWindow.cpp
@@ -239,6 +239,10 @@ void MainWindow::updateProfiles(int num)
         {
             ids5->updateProfiles();
         }
+        if (egg5)
+        {
+            egg5->updateProfiles();
+        }
     }
 }
 

--- a/Source/Forms/MainWindow.cpp
+++ b/Source/Forms/MainWindow.cpp
@@ -243,6 +243,10 @@ void MainWindow::updateProfiles(int num)
         {
             egg5->updateProfiles();
         }
+        if (hiddenGrotto)
+        {
+            hiddenGrotto->updateProfiles();
+        }
     }
 }
 


### PR DESCRIPTION
Changes made:
- Stationary Profile Manager button now works as intended (previously did not work)
- Eggs and Hidden Grotto now update the profile info displayed when a profile has been edited