### PR TITLE
[Gen 8] Fixed egg PID generation

### DIFF
--- a/Source/Core/Gen8/Generators/EggGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/EggGenerator8.cpp
@@ -39,7 +39,7 @@ std::vector<EggState> EggGenerator8::generate(u64 seed0, u64 seed1) const
 
     RNGList<u32, Xorshift, 2, 0> rngList(rng);
 
-    u8 pidRolls = 0;
+    u8 pidRolls = 1;
     if (daycare.getMasuda())
     {
         pidRolls += 6;


### PR DESCRIPTION
The PID wasn't getting rolled without Masuda method or shiny charm leading to all PIDs being 0