### PR TITLE
Add support for Nix flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ out
 i18n.hpp
 Encounters.hpp
 Personal.hpp
+
+# Nix
+result/

--- a/Source/Core/Util/EncounterSlot.cpp
+++ b/Source/Core/Util/EncounterSlot.cpp
@@ -26,7 +26,7 @@ namespace
     template <u32 size, bool greater = false>
     u8 calcSlot(u8 compare, const std::array<u8, size> &ranges)
     {
-        for (size_t i = 0; i < size; i++)
+        for (std::size_t i = 0; i < size; i++)
         {
             if constexpr (greater)
             {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658380158,
+        "narHash": "sha256-DBunkegKWlxPZiOcw3/SNIFg93amkdGIy2g0y/jDpHg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a65b5b3f5504b8b89c196aba733bdf2b0bd13c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Cross platform Pokémon RNG tool";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.default =
+      with import nixpkgs { system = "x86_64-linux"; };
+      stdenv.mkDerivation {
+        name = "PokeFinder";
+        #version = "4.0.0";
+        src = self;
+
+        nativeBuildInputs = [
+          cmake
+          qt6.wrapQtAppsHook
+        ];
+
+        buildInputs = [
+          python3
+          qt6.qttools
+          qt6.qtwayland
+        ];
+
+        cmakeFlags = [
+          "\"-GUnix Makefiles\""
+        ];
+
+        preBuild = ''
+          patchShebangs ../Source/Core/Resources/embed.py
+        '';
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp Source/Forms/PokeFinder $out/bin
+        '';
+      };
+  };
+}


### PR DESCRIPTION
### Introduction
Hello, I'm a user of NixOS and I wanted to try out your program on it but couldn't due to the pre-built binaries not being statically linked and NixOS not having traditional library paths. So I decided to build the project from source and thought I might as well as contribute what I have.

In case you're not aware, here's a short rationale for why to use/support Nix: https://nixos.org/guides/nix-pills/why-you-should-give-it-a-try.html

Nix flakes is an experimental feature that serves as "the unit for packaging Nix code in a reproducible and discoverable way." [0]

---

### TODO

This is my first flake I've written so I prioritised on getting it working over making it perfect. As such, there's a few more things to do.

NixOS supports the following platforms: https://nixos.org/manual/nix/stable/installation/supported-platforms.html

- [ ] Successfully build for all platforms
  - [ ] Linux
    - [ ] i686
    - [x] x86_64
    - [ ] aarch64
    - [ ] Xorg
    - [x] Wayland
  - [ ] macOS
    - [ ] x86_64
    - [ ] aarch64

I don't know if I care for all of this, but I think I should probably at least support Xorg.

---

### Usage

To build and run the project:
```sh-session
$ nix build .?submodules=1
$ ./result/bin/PokeFinder
```

To reproduce the development environment:
```sh-session
$ git submodule update --init
$ nix develop
```

---

# References

[0] - https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#description