### PR TITLE
Add std:: namespace to size_t

### DIFF
--- a/Source/Core/Util/EncounterSlot.cpp
+++ b/Source/Core/Util/EncounterSlot.cpp
@@ -26,7 +26,7 @@ namespace
     template <u32 size, bool greater = false>
     u8 calcSlot(u8 compare, const std::array<u8, size> &ranges)
     {
-        for (size_t i = 0; i < size; i++)
+        for (std::size_t i = 0; i < size; i++)
         {
             if constexpr (greater)
             {


### PR DESCRIPTION
Compilation fails against tag v4.0.0 on gcc 10.2.1. This change fixed build on origin/master with my other laptop about an hour ago, but it looks like 1edea7f935e14f29066f2d309752b6eda4b36d2e broke the build for me on this other machine.

Didn't look too deep into the latter issue yet, but this seems to be one of the things the build complains about, anyway.