### PR TITLE
Fix BDSP Unown form rand call location

### DIFF
--- a/Source/Core/Gen8/Generators/WildGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/WildGenerator8.cpp
@@ -43,6 +43,10 @@ std::vector<WildState> WildGenerator8::generate(u64 seed0, u64 seed1, const Enco
         WildState state(initialAdvances + cnt);
         Xorshift gen(rng);
         u8 slotPercent = gen.next<0, 100>();
+        if (encounterArea.getLocation() > 222 && encounterArea.getLocation() < 244)
+        { // Unown form call
+            gen.next(); // gen.next<0,1>() for F/R/I/E/N/D, gen.next<0,2>() for !/?, gen.next<0,20>() otherwise
+        }
         gen.advance(84);
         switch (encounter)
         {
@@ -111,11 +115,6 @@ std::vector<WildState> WildGenerator8::generate(u64 seed0, u64 seed1, const Enco
         }
 
         state.setAbility(gen.next() % 2);
-
-        if (encounterArea.getLocation() > 222 && encounterArea.getLocation() < 244)
-        { // TODO: add unown check
-            u32 unownForm = gen.next() % 28; // Form call
-        }
 
         if (genderRatio == 255)
         {


### PR DESCRIPTION
Fixes Admiral-Fish#248

```// gen.next<0,1>() for F/R/I/E/N/D, gen.next<0,2>() for !/?, gen.next<0,20>() otherwise```
refers to the range of the rand depending on which room of solaceon you are in, this is only important for displaying the form as no matter the range it does 1 xorshift call.