### PR TITLE
Add missing `<bit>` header

### DIFF
--- a/Source/Core/Gen5/Keypresses.cpp
+++ b/Source/Core/Gen5/Keypresses.cpp
@@ -20,6 +20,7 @@
 #include "Keypresses.hpp"
 #include <Core/Enum/Buttons.hpp>
 #include <Core/Gen5/Profile5.hpp>
+#include <bit>
 
 /**
  * @brief Determines if the selected key presses are valid


### PR DESCRIPTION
The missing header caused the following compilation issues on NixOS:
```
       > [ 27%] Building CXX object Source/Core/CMakeFiles/PokeFinderCore.dir/Gen5/Filters/StateFilter5.cpp.o
       > /build/source/Source/Core/Gen5/Keypresses.cpp: In function 'std::vector<Keypress> Keypresses::getKeypresses(const Profile5&)':
       > /build/source/Source/Core/Gen5/Keypresses.cpp:71:30: error: 'popcount' is not a member of 'std'
       >    71 |             int count = std::popcount(bits);
       >       |                              ^~~~~~~~
       > [ 28%] Building CXX object Source/Core/CMakeFiles/PokeFinderCore.dir/Gen5/Generators/DreamRadarGenerator.cpp.o
```