### PR TITLE
Revert "Fix BDSP Shiny Checks (#296)"

### DIFF
--- a/Source/Core/Gen8/Generators/EggGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/EggGenerator8.cpp
@@ -36,7 +36,6 @@ EggGenerator8::EggGenerator8(u32 initialAdvances, u32 maxAdvances, u32 delay, u8
     EggGenerator(initialAdvances, maxAdvances, delay, Method::None, compatability, daycare, profile, filter),
     shinyCharm(profile.getShinyCharm())
 {
-    tsv = (profile.getTID() & 0xFFF0) ^ profile.getSID();
 }
 
 std::vector<EggGeneratorState> EggGenerator8::generate(u64 seed0, u64 seed1) const
@@ -183,7 +182,7 @@ std::vector<EggGeneratorState> EggGenerator8::generate(u64 seed0, u64 seed1) con
             for (u8 roll = 0; roll < pidRolls; roll++)
             {
                 pid = rng.nextUInt(0xffffffff);
-                psv = (pid >> 16) ^ (pid & 0xfff0);
+                psv = (pid >> 16) ^ (pid & 0xffff);
                 if ((psv ^ tsv) < 16)
                 {
                     break;

--- a/Source/Core/Gen8/Generators/EventGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/EventGenerator8.cpp
@@ -55,7 +55,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 0:
         {
             pid = rngList.next();
-            u16 psv = (pid >> 16) & (pid & 0xffff);
+            u16 psv = (pid >> 16) ^ (pid & 0xffff);
 
             if ((psv ^ tsv) < 16)
             {
@@ -68,7 +68,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 2:
         {
             pid = rngList.next();
-            u16 psv = (pid >> 16) & (pid & 0xffff);
+            u16 psv = (pid >> 16) ^ (pid & 0xffff);
 
             u16 realXOR = psv ^ tsv;
             u8 shinyType = realXOR == 0 ? 2 : realXOR < 16 ? 1 : 0;
@@ -85,7 +85,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 4:
         {
             pid = wb8.getPID();
-            u16 realXor = (pid >> 16) & (pid & 0xffff) ^ tsv;
+            u16 realXor = (pid >> 16) ^ (pid & 0xffff) ^ tsv;
             shiny = realXor == 0 ? 2 : realXor < 16 ? 1 : 0;
             break;
         }

--- a/Source/Core/Gen8/Generators/EventGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/EventGenerator8.cpp
@@ -34,11 +34,7 @@ EventGenerator8::EventGenerator8(u32 initialAdvances, u32 maxAdvances, u32 delay
 {
     if (!wb8.getEgg())
     {
-        tsv = (wb8.getTID() & 0xFFF0) ^ wb8.getSID();
-    }
-    else
-    {
-        tsv = (profile.getTID() & 0xFFF0) ^ profile.getSID();
+        tsv = wb8.getTID() ^ wb8.getSID();
     }
 }
 
@@ -59,7 +55,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 0:
         {
             pid = rngList.next();
-            u16 psv = (pid >> 16) ^ (pid & 0xfff0);
+            u16 psv = (pid >> 16) & (pid & 0xffff);
 
             if ((psv ^ tsv) < 16)
             {
@@ -72,7 +68,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 2:
         {
             pid = rngList.next();
-            u16 psv = (pid >> 16) ^ (pid & 0xfff0);
+            u16 psv = (pid >> 16) & (pid & 0xffff);
 
             u16 realXOR = psv ^ tsv;
             u8 shinyType = realXOR == 0 ? 2 : realXOR < 16 ? 1 : 0;
@@ -89,7 +85,7 @@ std::vector<GeneratorState> EventGenerator8::generate(u64 seed0, u64 seed1) cons
         case 4:
         {
             pid = wb8.getPID();
-            u16 realXor = (pid >> 16) ^ (pid & 0xfff0) ^ tsv;
+            u16 realXor = (pid >> 16) & (pid & 0xffff) ^ tsv;
             shiny = realXor == 0 ? 2 : realXor < 16 ? 1 : 0;
             break;
         }

--- a/Source/Core/Gen8/Generators/StaticGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/StaticGenerator8.cpp
@@ -36,7 +36,6 @@ StaticGenerator8::StaticGenerator8(u32 initialAdvances, u32 maxAdvances, u32 del
                                    const StateFilter &filter) :
     StaticGenerator(initialAdvances, maxAdvances, delay, Method::None, lead, profile, filter)
 {
-    tsv = (profile.getTID() & 0xFFF0) ^ profile.getSID();
 }
 
 std::vector<GeneratorState> StaticGenerator8::generate(u64 seed0, u64 seed1, const StaticTemplate *staticTemplate) const
@@ -51,7 +50,7 @@ std::vector<GeneratorState> StaticGenerator8::generate(u64 seed0, u64 seed1, con
         u32 sidtid = rngList.next();
         u32 pid = rngList.next();
 
-        u16 psv = (pid >> 16) ^ (pid & 0xfff0);
+        u16 psv = (pid >> 16) ^ (pid & 0xffff);
         u8 shiny;
         if (staticTemplate->getShiny() == Shiny::Never)
         {
@@ -63,7 +62,7 @@ std::vector<GeneratorState> StaticGenerator8::generate(u64 seed0, u64 seed1, con
         }
         else
         {
-            u16 fakeXOR = (sidtid >> 16) ^ (sidtid & 0xfff0) ^ psv;
+            u16 fakeXOR = (sidtid >> 16) ^ (sidtid & 0xffff) ^ psv;
             if (fakeXOR < 16) // Force shiny
             {
                 shiny = fakeXOR == 0 ? 2 : 1;
@@ -178,8 +177,8 @@ std::vector<GeneratorState> StaticGenerator8::generateRoamer(u64 seed0, u64 seed
         u32 sidtid = rng.nextUInt(0xffffffff);
         u32 pid = rng.nextUInt(0xffffffff);
 
-        u16 psv = (pid >> 16) ^ (pid & 0xfff0);
-        u16 fakeXOR = (sidtid >> 16) ^ (sidtid & 0xfff0) ^ psv;
+        u16 psv = (pid >> 16) ^ (pid & 0xffff);
+        u16 fakeXOR = (sidtid >> 16) ^ (sidtid & 0xffff) ^ psv;
         u8 shiny;
         if (fakeXOR < 16) // Force shiny
         {

--- a/Source/Core/Gen8/Generators/UndergroundGenerator.cpp
+++ b/Source/Core/Gen8/Generators/UndergroundGenerator.cpp
@@ -241,7 +241,6 @@ UndergroundGenerator::UndergroundGenerator(u32 initialAdvances, u32 maxAdvances,
                                            const Profile8 &profile, const UndergroundStateFilter &filter) :
     StaticGenerator(initialAdvances, maxAdvances, delay, Method::None, lead, profile, filter), diglett(diglett), levelFlag(levelFlag)
 {
-    tsv = (profile.getTID() & 0xFFF0) ^ profile.getSID();
 }
 
 std::vector<UndergroundState> UndergroundGenerator::generate(u64 seed0, u64 seed1, const UndergroundArea &encounterArea) const
@@ -271,8 +270,8 @@ std::vector<UndergroundState> UndergroundGenerator::generate(u64 seed0, u64 seed
         {
             pid = rngList.next(rand);
 
-            u16 psv = (pid >> 16) ^ (pid & 0xfff0);
-            u16 fakeXor = (sidtid >> 16) ^ (sidtid & 0xfff0) ^ psv;
+            u16 psv = (pid >> 16) ^ (pid & 0xffff);
+            u16 fakeXor = (sidtid >> 16) ^ (sidtid & 0xffff) ^ psv;
 
             if (fakeXor < 16) // Force shiny
             {

--- a/Source/Core/Gen8/Generators/WildGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/WildGenerator8.cpp
@@ -61,7 +61,6 @@ WildGenerator8::WildGenerator8(u32 initialAdvances, u32 maxAdvances, u32 delay, 
                                const Profile8 &profile, const WildStateFilter &filter) :
     WildGenerator(initialAdvances, maxAdvances, delay, Method::None, lead, area, profile, filter)
 {
-    tsv = (profile.getTID() & 0xFFF0) ^ profile.getSID();
 }
 
 std::vector<WildGeneratorState> WildGenerator8::generate(u64 seed0, u64 seed1) const
@@ -113,8 +112,8 @@ std::vector<WildGeneratorState> WildGenerator8::generate(u64 seed0, u64 seed1) c
         u32 sidtid = rngList.next(rand);
         u32 pid = rngList.next(rand);
 
-        u16 psv = (pid >> 16) ^ (pid & 0xfff0);
-        u16 fakeXor = (sidtid >> 16) ^ (sidtid & 0xfff0) ^ psv;
+        u16 psv = (pid >> 16) ^ (pid & 0xffff);
+        u16 fakeXor = (sidtid >> 16) ^ (sidtid & 0xffff) ^ psv;
         u8 shiny;
         if (fakeXor < 16) // Force shiny
         {


### PR DESCRIPTION
This reverts commit e70a0423faa9d374097b1dd1ffe163c7b69930fc.

For context, the masking is only for the fakeXor and is irrelevant for overall shiny checks. Square check still uses the full bitmask for short values.