### PR TITLE
Add missing #include to JirachiPattern.cpp

### DIFF
--- a/Source/Core/Gen3/Tools/JirachiPattern.cpp
+++ b/Source/Core/Gen3/Tools/JirachiPattern.cpp
@@ -19,6 +19,7 @@
 
 #include "JirachiPattern.hpp"
 #include <Core/RNG/LCRNG.hpp>
+#include <algorithm>
 
 /**
  * @brief Does the advance from playing the cutscene


### PR DESCRIPTION
`std::count` is used, but `<algorithm>` isn't included. This breaks the build on NixOS (and presumably other distros using the same libstdc++ version?).