### PR TITLE
Allow IV filters to ignore inherited stats

### DIFF
--- a/Source/Core/Gen3/Generators/EggGenerator3.cpp
+++ b/Source/Core/Gen3/Generators/EggGenerator3.cpp
@@ -117,7 +117,7 @@ static void setInheritance(const Daycare &daycare, std::array<u8, 6> &ivs, std::
 
 EggGenerator3::EggGenerator3(u32 initialAdvances, u32 maxAdvances, u32 delay, u32 initialAdvancesPickup, u32 maxAdvancesPickup,
                              u32 delayPickup, u8 calibration, u8 minRedraw, u8 maxRedraw, Method method, u8 compatability,
-                             const Daycare &daycare, const Profile3 &profile, const StateFilter &filter) :
+                             const Daycare &daycare, const Profile3 &profile, const DaycareFilter &filter) :
     EggGenerator(initialAdvances, maxAdvances, delay, method, compatability, daycare, profile, filter),
     delayPickup(delayPickup),
     initialAdvancesPickup(initialAdvancesPickup),
@@ -354,7 +354,7 @@ std::vector<EggState3> EggGenerator3::generateEmeraldPickup(const std::vector<Eg
 
             state.update(initialAdvancesPickup + cnt, ivs, inheritance, info);
             if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareNature(state.getNature())
-                && filter.compareShiny(state.getShiny()) && filter.compareIV(state.getIVs()))
+                && filter.compareShiny(state.getShiny()) && filter.compareIV(state.getIVs(), inheritance))
             {
                 states.emplace_back(state);
             }
@@ -465,7 +465,7 @@ std::vector<EggState3> EggGenerator3::generateRSFRLGPickup(u32 seed, const std::
 
             state.update(initialAdvancesPickup + cnt, pid, Utilities::getShiny<true>(pid, tsv), ivs, inheritance, info);
             if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareNature(state.getNature())
-                && filter.compareShiny(state.getShiny()) && filter.compareIV(state.getIVs()))
+                && filter.compareShiny(state.getShiny()) && filter.compareIV(state.getIVs(), inheritance))
             {
                 states.emplace_back(state);
             }

--- a/Source/Core/Gen3/Generators/EggGenerator3.hpp
+++ b/Source/Core/Gen3/Generators/EggGenerator3.hpp
@@ -29,7 +29,7 @@ class EggState3;
 /**
  * @brief Egg encounter generator for Gen3
  */
-class EggGenerator3 : public EggGenerator<Profile3, StateFilter>
+class EggGenerator3 : public EggGenerator<Profile3, DaycareFilter>
 {
 public:
     /**
@@ -52,7 +52,7 @@ public:
      */
     EggGenerator3(u32 initialAdvances, u32 maxAdvances, u32 delay, u32 initialAdvancesPickup, u32 maxAdvancesPickup, u32 delayPickup,
                   u8 calibration, u8 minRedraw, u8 maxRedraw, Method method, u8 compatability, const Daycare &daycare,
-                  const Profile3 &profile, const StateFilter &filter);
+                  const Profile3 &profile, const DaycareFilter &filter);
 
     /**
      * @brief Generates states

--- a/Source/Core/Gen4/Generators/EggGenerator4.cpp
+++ b/Source/Core/Gen4/Generators/EggGenerator4.cpp
@@ -115,7 +115,7 @@ static void setInheritance(const Daycare &daycare, std::array<u8, 6> &ivs, std::
 }
 
 EggGenerator4::EggGenerator4(u32 initialAdvances, u32 maxAdvances, u32 delay, u32 initialAdvancesPickup, u32 maxAdvancesPickup,
-                             u32 delayPickup, const Daycare &daycare, const Profile4 &profile, const StateFilter &filter) :
+                             u32 delayPickup, const Daycare &daycare, const Profile4 &profile, const DaycareFilter &filter) :
     EggGenerator(initialAdvances, maxAdvances, delay, Method::None, 0, daycare, profile, filter),
     delayPickup(delayPickup),
     initialAdvancesPickup(initialAdvancesPickup),
@@ -237,7 +237,7 @@ std::vector<EggGeneratorState4> EggGenerator4::generatePickup(u32 seed, const st
             }
 
             state.update(prng, initialAdvancesPickup + cnt, ivs, inheritance, info);
-            if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareIV(state.getIVs()))
+            if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareIV(state.getIVs(), inheritance))
             {
                 states.emplace_back(state);
             }

--- a/Source/Core/Gen4/Generators/EggGenerator4.hpp
+++ b/Source/Core/Gen4/Generators/EggGenerator4.hpp
@@ -29,7 +29,7 @@ class EggGeneratorState4;
 /**
  * @brief Egg encounter generator for Gen4
  */
-class EggGenerator4 : public EggGenerator<Profile4, StateFilter>
+class EggGenerator4 : public EggGenerator<Profile4, DaycareFilter>
 {
 public:
     /**
@@ -46,7 +46,7 @@ public:
      * @param filter State filter
      */
     EggGenerator4(u32 initialAdvances, u32 maxAdvances, u32 delay, u32 initialAdvancesPickup, u32 maxAdvancesPickup, u32 delayPickup,
-                  const Daycare &daycare, const Profile4 &profile, const StateFilter &filter);
+                  const Daycare &daycare, const Profile4 &profile, const DaycareFilter &filter);
 
     /**
      * @brief Generates states

--- a/Source/Core/Gen5/Generators/EggGenerator5.cpp
+++ b/Source/Core/Gen5/Generators/EggGenerator5.cpp
@@ -28,7 +28,7 @@
 #include <Core/Util/Utilities.hpp>
 
 EggGenerator5::EggGenerator5(u32 initialAdvances, u32 maxAdvances, u32 delay, const Daycare &daycare, const Profile5 &profile,
-                             const StateFilter &filter) :
+                             const DaycareFilter &filter) :
     EggGenerator(initialAdvances, maxAdvances, delay, Method::None, 0, daycare, profile, filter),
     ditto(daycare.getDitto()),
     everstone(daycare.getEverstoneCount()),
@@ -174,7 +174,8 @@ std::vector<EggState5> EggGenerator5::generateBW(u64 seed) const
 
         EggState5 state(rng.nextUInt(0x1fff), advances + initialAdvances + cnt, pid, ivs, ability, Utilities::getGender(pid, info), nature,
                         Utilities::getShiny<true>(pid, tsv), inheritance, info);
-        if (filter.compareState(static_cast<const State &>(state)))
+
+        if (filter.compareState(static_cast<const EggState &>(state)))
         {
             states.emplace_back(state);
         }
@@ -194,7 +195,7 @@ std::vector<EggState5> EggGenerator5::generateBW2(u64 seed) const
 
     const PersonalInfo *info = nullptr;
     EggState5 state = generateBW2Egg(eggSeed, &info);
-    if (filter.compareAbility(state.getAbility()) && filter.compareNature(state.getNature()) && filter.compareIV(state.getIVs())
+    if (filter.compareAbility(state.getAbility()) && filter.compareNature(state.getNature()) && filter.compareIV(state.getIVs(), state.getInheritance())
         && filter.compareHiddenPower(state.getHiddenPower()))
     {
         u32 advances = Utilities5::initialAdvances(seed, profile);

--- a/Source/Core/Gen5/Generators/EggGenerator5.hpp
+++ b/Source/Core/Gen5/Generators/EggGenerator5.hpp
@@ -30,7 +30,7 @@ class PersonalInfo;
 /**
  * @brief Egg generator for Gen 5
  */
-class EggGenerator5 : public EggGenerator<Profile5, StateFilter>
+class EggGenerator5 : public EggGenerator<Profile5, DaycareFilter>
 {
 public:
     /**
@@ -44,7 +44,7 @@ public:
      * @param filter State filter
      */
     EggGenerator5(u32 initialAdvances, u32 maxAdvances, u32 delay, const Daycare &daycare, const Profile5 &profile,
-                  const StateFilter &filter);
+                  const DaycareFilter &filter);
 
     /**
      * @brief Generates states

--- a/Source/Core/Gen8/Generators/EggGenerator8.cpp
+++ b/Source/Core/Gen8/Generators/EggGenerator8.cpp
@@ -33,7 +33,7 @@ static u32 gen(Xorshift &rng)
 }
 
 EggGenerator8::EggGenerator8(u32 initialAdvances, u32 maxAdvances, u32 delay, u8 compatability, const Daycare &daycare,
-                             const Profile8 &profile, const StateFilter &filter) :
+                             const Profile8 &profile, const DaycareFilter &filter) :
     EggGenerator(initialAdvances, maxAdvances, delay, Method::None, compatability, daycare, profile, filter),
     shinyCharm(profile.getShinyCharm())
 {
@@ -193,7 +193,7 @@ std::vector<EggGeneratorState> EggGenerator8::generate(u64 seed0, u64 seed1) con
 
             EggGeneratorState state(initialAdvances + cnt, ec, pid, ivs, ability, gender, 1, nature, Utilities::getShiny<false>(pid, tsv),
                                     inheritance, info);
-            if (filter.compareState(static_cast<const State &>(state)))
+            if (filter.compareState(static_cast<const EggState &>(state)))
             {
                 states.emplace_back(state);
             }

--- a/Source/Core/Gen8/Generators/EggGenerator8.hpp
+++ b/Source/Core/Gen8/Generators/EggGenerator8.hpp
@@ -29,7 +29,7 @@ class EggGeneratorState;
 /**
  * @brief Egg generator for Gen8
  */
-class EggGenerator8 : public EggGenerator<Profile8, StateFilter>
+class EggGenerator8 : public EggGenerator<Profile8, DaycareFilter>
 {
 public:
     /**
@@ -44,7 +44,7 @@ public:
      * @param filter State filter
      */
     EggGenerator8(u32 initialAdvances, u32 maxAdvances, u32 delay, u8 compatability, const Daycare &daycare, const Profile8 &profile,
-                  const StateFilter &filter);
+                  const DaycareFilter &filter);
 
     /**
      * @brief Generates states

--- a/Source/Core/Parents/Filters/StateFilter.cpp
+++ b/Source/Core/Parents/Filters/StateFilter.cpp
@@ -19,6 +19,8 @@
 
 #include "StateFilter.hpp"
 #include <Core/Parents/States/WildState.hpp>
+#include <Core/Parents/States/EggState.hpp>
+
 
 StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, bool skip, const std::array<u8, 6> &min, const std::array<u8, 6> &max,
                          const std::array<bool, 25> &natures, const std::array<bool, 16> &powers) :
@@ -218,4 +220,86 @@ bool WildStateFilter::compareState(const WildSearcherState &state) const
 bool WildStateFilter::compareState(const WildState &state) const
 {
     return StateFilter::compareState(static_cast<const State &>(state)) && encounterSlots[state.getEncounterSlot()];
+}
+
+DaycareFilter::DaycareFilter(u8 gender, u8 ability, u8 shiny, bool skip, const std::array<u8, 6> &min, const std::array<u8, 6> &max,
+                                 const std::array<bool, 25> &natures, const std::array<bool, 16> &powers, bool ignoreInheritance) :
+    StateFilter(gender, ability, shiny, skip, min, max, natures, powers), ignoreInheritance(ignoreInheritance)
+{
+}
+
+bool DaycareFilter::compareState(const EggState &state) const
+{
+    if (skip)
+    {
+        return true;
+    }
+
+    if (ability != 255 && ability != state.getAbility())
+    {
+        return false;
+    }
+
+    if (gender != 255 && gender != state.getGender())
+    {
+        return false;
+    }
+
+    if (!powers[state.getHiddenPower()])
+    {
+        return false;
+    }
+
+    if (!natures[state.getNature()])
+    {
+        return false;
+    }
+
+    if (shiny != 255 && !(shiny & state.getShiny()))
+    {
+        return false;
+    }
+
+
+    for (int i = 0; i < 6; i++)
+    {
+
+        if (ignoreInheritance && state.getInheritance(i) != 0){
+            continue;
+        }
+
+        u8 iv = state.getIV(i);
+        if (iv < min[i] || iv > max[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
+
+}
+
+
+bool DaycareFilter::compareIV(const std::array<u8, 6> &ivs, const std::array<u8, 6> &inheritance) const
+{
+    if (skip)
+    {
+        return true;
+    }
+
+    for (int i = 0; i < 6; i++)
+    {
+
+        if (ignoreInheritance && inheritance[i] != 0){
+            continue;
+        }
+
+        u8 iv = ivs[i];
+        if (iv < min[i] || iv > max[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/Source/Core/Parents/Filters/StateFilter.hpp
+++ b/Source/Core/Parents/Filters/StateFilter.hpp
@@ -23,11 +23,15 @@
 #include <Core/Global.hpp>
 #include <array>
 
+
 class SearcherState;
 class State;
 class WildGeneratorState;
 class WildSearcherState;
 class WildState;
+class EggState;
+
+
 
 /**
  * @brief Provides ways to determine if the given \ref State meets the given criteria
@@ -211,5 +215,46 @@ public:
 protected:
     std::array<bool, 12> encounterSlots;
 };
+
+class DaycareFilter : public StateFilter
+{
+public:
+
+    /**
+     * @brief Construct a new DaycareFilter object
+     *
+     * @param gender Gender value to filter by
+     * @param ability Ability value to filter by
+     * @param shiny Shiny value to filter by
+     * @param skip If filters should be skipped
+     * @param min Minimum IV thresholds
+     * @param max Maximum IV thresholds
+     * @param natures Natures to filter by
+     * @param powers Hidden powers to filter by
+     * @param ignoreInheritance If IV filters should ignore inherited stats
+     */
+    DaycareFilter(u8 gender, u8 ability, u8 shiny, bool skip, const std::array<u8, 6> &min, const std::array<u8, 6> &max,
+                    const std::array<bool, 25> &natures, const std::array<bool, 16> &powers, bool ignoreInheritance);
+
+    /**
+     * @brief Determines if the \p ivs meet the filter criteria
+     *
+     * @param ivs IVs to compare
+     * @param inheritance Which stats come from which parent
+     *
+     * @return true IVs pass the filter
+     * @return false IVs do not pass the filter
+     */
+    bool compareIV(const std::array<u8, 6> &ivs, const std::array<u8, 6> &inheritance) const;
+
+    bool compareState(const EggState &state) const;
+
+
+
+protected:
+    bool ignoreInheritance;
+};
+
+
 
 #endif // STATEFILTER_HPP

--- a/Source/Core/Parents/States/WildState.hpp
+++ b/Source/Core/Parents/States/WildState.hpp
@@ -22,6 +22,7 @@
 
 #include <Core/Parents/States/State.hpp>
 
+
 /**
  * @brief Parent state class that provides additional wild information
  */

--- a/Source/Form/Controls/Controls.hpp
+++ b/Source/Form/Controls/Controls.hpp
@@ -35,7 +35,8 @@ enum class Controls : u16
     HiddenPowers = 1 << 4,
     Natures = 1 << 5,
     Shiny = 1 << 6,
-    DisableFilter = 1 << 7
+    DisableFilter = 1 << 7,
+    IgnoreInheritance = 1 << 8
 };
 
 /**

--- a/Source/Form/Controls/Filter.cpp
+++ b/Source/Form/Controls/Filter.cpp
@@ -177,6 +177,12 @@ void Filter::disableControls(Controls control)
     {
         ui->checkBoxDisableFilters->setVisible(false);
     }
+
+    if ((control & Controls::IgnoreInheritance) != Controls::None)
+    {
+        ui->checkBoxIgnoreInheritance->setVisible(false);
+    }
+
 }
 
 void Filter::enableHiddenAbility()
@@ -192,6 +198,11 @@ u8 Filter::getAbility() const
 bool Filter::getDisableFilters() const
 {
     return ui->checkBoxDisableFilters->isChecked();
+}
+
+bool Filter::getIgnoreInheritance() const
+{
+    return ui->checkBoxIgnoreInheritance->isChecked();
 }
 
 std::array<bool, 12> Filter::getEncounterSlots() const

--- a/Source/Form/Controls/Filter.hpp
+++ b/Source/Form/Controls/Filter.hpp
@@ -32,6 +32,16 @@ namespace Ui
 }
 
 /**
+ * @brief Enum that lists the different Filter types
+ */
+enum filter_types
+{
+    FILTER_STATE_FILTER = 0,
+    FILTER_WILD_FILTER = 1,
+    FILTER_DAYCARE_FILTER = 2
+};
+
+/**
  * @brief Provides settings to filter results on
  */
 class Filter : public QWidget
@@ -84,6 +94,14 @@ public:
     bool getDisableFilters() const;
 
     /**
+     * @brief Checks if IV filters should ignore inherited stats
+     *
+     * @return true IV filters automatically pass inherited stats
+     * @return false IV filters check inherited stats
+     */
+    bool getIgnoreInheritance() const;
+
+    /**
      * @brief Gets encounter slots to filter by
      *
      * @return Array of encounter slots
@@ -94,22 +112,27 @@ public:
      * @brief Constructs filter from the UI settings
      *
      * @tparam FilterType Filter class type
-     * @tparam wild Whether filter is for wild encounters
+     * @tparam type dictating type of constructor signature is needed
      *
      * @return Filter object
      */
-    template <class FilterType, bool wild = false>
+    template <class FilterType, u16 type>
     FilterType getFilter() const
     {
-        if constexpr (wild)
-        {
+
+        if constexpr(type == 1){
+            assert(type == 1);
             return FilterType(getGender(), getAbility(), getShiny(), getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(),
                               getHiddenPowers(), getEncounterSlots());
         }
-        else
-        {
+        else if constexpr(type == 2){
+            assert(type == 2);
             return FilterType(getGender(), getAbility(), getShiny(), getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(),
-                              getHiddenPowers());
+                              getHiddenPowers(), getIgnoreInheritance());
+        }
+        else{
+        return FilterType(getGender(), getAbility(), getShiny(), getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(),
+                          getHiddenPowers());
         }
     }
 

--- a/Source/Form/Controls/Filter.ui
+++ b/Source/Form/Controls/Filter.ui
@@ -288,10 +288,17 @@
      <item row="2" column="3">
       <widget class="CheckList" name="checkListNature"/>
      </item>
-     <item row="3" column="0" colspan="4">
+     <item row="3" column="0" colspan="2">
       <widget class="QCheckBox" name="checkBoxDisableFilters">
        <property name="text">
         <string>Disable Filters</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2" colspan="2">
+      <widget class="QCheckBox" name="checkBoxIgnoreInheritance">
+       <property name="text">
+        <string>Ignore Inheritance</string>
        </property>
       </widget>
      </item>

--- a/Source/Form/Gen3/Eggs3.cpp
+++ b/Source/Form/Gen3/Eggs3.cpp
@@ -145,7 +145,7 @@ void Eggs3::emeraldGenerate()
     u8 compatability = ui->comboBoxEmeraldCompatibility->getCurrentUChar();
     auto method = ui->comboBoxEmeraldMethod->getEnum<Method>();
 
-    auto filter = ui->filterEmerald->getFilter<StateFilter>();
+    auto filter = ui->filterEmerald->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator3 generator(initialAdvancesHeld, maxAdvancesHeld, delayHeld, initialAdvancesPickup, maxAdvancesPickup, delayPickup,
                             calibration, minRedraw, maxRedraw, method, compatability, ui->eggSettingsEmerald->getDaycare(), *currentProfile,
                             filter);
@@ -174,7 +174,7 @@ void Eggs3::rsfrlgGenerate()
     u8 compatability = ui->comboBoxRSFRLGCompatibility->getCurrentUChar();
     auto method = ui->comboBoxRSFRLGMethod->getEnum<Method>();
 
-    auto filter = ui->filterRSFRLG->getFilter<StateFilter>();
+    auto filter = ui->filterRSFRLG->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator3 generator(initialAdvancesHeld, maxAdvancesHeld, delayHeld, initialAdvancesPickup, maxAdvancesPickup, delayPickup, 0, 0, 0,
                             method, compatability, ui->eggSettingsRSFRLG->getDaycare(), *currentProfile, filter);
 

--- a/Source/Form/Gen3/GameCube.cpp
+++ b/Source/Form/Gen3/GameCube.cpp
@@ -53,8 +53,8 @@ GameCube::GameCube(QWidget *parent) : QWidget(parent), ui(new Ui::GameCube)
     ui->textBoxGeneratorMaxAdvances->setValues(InputType::Advance32Bit);
     ui->textBoxGeneratorDelay->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots);
-    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
+    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     ui->comboBoxGeneratorPokemon->enableAutoComplete();
     ui->comboBoxSearcherPokemon->enableAutoComplete();
@@ -125,7 +125,7 @@ void GameCube::generate()
     u32 maxAdvances = ui->textBoxGeneratorMaxAdvances->getUInt();
     u32 delay = ui->textBoxGeneratorDelay->getUInt();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     GameCubeGenerator generator(initialAdvances, maxAdvances, delay, method, ui->checkBoxGeneratorFirstShadowUnset->isChecked(),
                                 *currentProfile, filter);
 
@@ -236,7 +236,7 @@ void GameCube::search()
     std::array<u8, 6> min = ui->filterSearcher->getMinIVs();
     std::array<u8, 6> max = ui->filterSearcher->getMaxIVs();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     auto *searcher = new GameCubeSearcher(method, ui->checkBoxSearcherFirstShadowUnset->isChecked(), *currentProfile, filter);
 
     int maxProgress = 1;

--- a/Source/Form/Gen3/Static3.cpp
+++ b/Source/Form/Gen3/Static3.cpp
@@ -56,8 +56,8 @@ Static3::Static3(QWidget *parent) : QWidget(parent), ui(new Ui::Static3)
     ui->comboBoxGeneratorMethod->setup({ toInt(Method::Method1), toInt(Method::Method4) });
     ui->comboBoxSearcherMethod->setup({ toInt(Method::Method1), toInt(Method::Method4) });
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots);
-    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
+    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     auto *seedToTime = new QAction(tr("Generate times for seed"), ui->tableViewSearcher);
     connect(seedToTime, &QAction::triggered, this, &Static3::seedToTime);
@@ -129,7 +129,7 @@ void Static3::generate()
     const StaticTemplate3 *staticTemplate
         = Encounters3::getStaticEncounter(ui->comboBoxGeneratorCategory->currentIndex(), ui->comboBoxGeneratorPokemon->getCurrentInt());
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     StaticGenerator3 generator(initialAdvances, maxAdvances, delay, method, *staticTemplate, *currentProfile, filter);
 
     auto states = generator.generate(seed);
@@ -216,7 +216,7 @@ void Static3::search()
     std::array<u8, 6> max = ui->filterSearcher->getMaxIVs();
     auto method = ui->comboBoxSearcherMethod->getEnum<Method>();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     auto *searcher = new StaticSearcher3(method, *currentProfile, filter);
 
     const StaticTemplate3 *staticTemplate

--- a/Source/Form/Gen3/Tools/PokeSpot.cpp
+++ b/Source/Form/Gen3/Tools/PokeSpot.cpp
@@ -133,7 +133,7 @@ void PokeSpot::generate()
     u32 delayFood = ui->textBoxFoodDelay->getUInt();
     u32 delayEncounter = ui->textBoxEncounterDelay->getUInt();
 
-    auto filter = ui->filter->getFilter<WildStateFilter, true>();
+    auto filter = ui->filter->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     PokeSpotGenerator generator(initialAdvancesFood, maxAdvancesFood, delayFood, initialAdvancesEncounter, maxAdvancesEncounter,
                                 delayEncounter, *currentProfile, filter);
 

--- a/Source/Form/Gen3/Wild3.cpp
+++ b/Source/Form/Gen3/Wild3.cpp
@@ -63,7 +63,8 @@ Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
     ui->comboBoxSearcherEncounter->setup({ toInt(Encounter::Grass), toInt(Encounter::RockSmash), toInt(Encounter::Surfing),
                                            toInt(Encounter::OldRod), toInt(Encounter::GoodRod), toInt(Encounter::SuperRod) });
 
-    ui->filterSearcher->disableControls(Controls::DisableFilter);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::IgnoreInheritance);
+    ui->filterGenerator->disableControls(Controls::IgnoreInheritance);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"), { tr("♂ Lead"), tr("♀ Lead") },
@@ -180,7 +181,7 @@ void Wild3::generate()
     auto lead = ui->comboMenuGeneratorLead->getEnum<Lead>();
     bool feebasTile = ui->checkBoxGeneratorFeebasTile->isChecked();
 
-    auto filter = ui->filterGenerator->getFilter<WildStateFilter, true>();
+    auto filter = ui->filterGenerator->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     WildGenerator3 generator(initialAdvances, maxAdvances, delay, method, lead, feebasTile,
                              encounterGenerator[ui->comboBoxGeneratorLocation->getCurrentInt()], *currentProfile, filter);
 
@@ -356,7 +357,7 @@ void Wild3::search()
     auto lead = ui->comboMenuSearcherLead->getEnum<Lead>();
     bool feebas = ui->checkBoxSearcherFeebasTile->isChecked();
 
-    auto filter = ui->filterSearcher->getFilter<WildStateFilter, true>();
+    auto filter = ui->filterSearcher->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     auto *searcher = new WildSearcher3(method, lead, feebas, encounterSearcher[ui->comboBoxSearcherLocation->getCurrentInt()],
                                        *currentProfile, filter);
 

--- a/Source/Form/Gen4/Eggs4.cpp
+++ b/Source/Form/Gen4/Eggs4.cpp
@@ -194,7 +194,7 @@ void Eggs4::generate()
     u32 maxAdvancesPickup = ui->textBoxGeneratorMaxAdvancesPickup->getUInt();
     u32 delayPickup = ui->textBoxGeneratorDelayPickup->getUInt();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator4 generator(initialAdvancesHeld, maxAdvancesHeld, delayHeld, initialAdvancesPickup, maxAdvancesPickup, delayPickup,
                             ui->eggSettingsGenerator->getDaycare(), *currentProfile, filter);
 
@@ -223,7 +223,7 @@ void Eggs4::search()
     u32 minDelay = ui->textBoxSearcherMinDelay->getUInt();
     u32 maxDelay = ui->textBoxSearcherMaxDelay->getUInt();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator4 generator(initialAdvancesHeld, maxAdvancesHeld, 0, initialAdvancesPickup, maxAdvancesPickup, 0,
                             ui->eggSettingsSearcher->getDaycare(), *currentProfile, filter);
 

--- a/Source/Form/Gen4/Event4.cpp
+++ b/Source/Form/Gen4/Event4.cpp
@@ -64,9 +64,9 @@ Event4::Event4(QWidget *parent) : QWidget(parent), ui(new Ui::Event4)
     }
 
     ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Ability | Controls::Gender | Controls::Natures
-                                         | Controls::Shiny);
+                                         | Controls::Shiny | Controls::IgnoreInheritance);
     ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::Ability | Controls::Gender | Controls::Natures
-                                        | Controls::Shiny | Controls::DisableFilter);
+                                        | Controls::Shiny | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     ui->filterGenerator->enableHiddenAbility();
     ui->filterSearcher->enableHiddenAbility();
@@ -159,7 +159,7 @@ void Event4::generate()
     u32 maxAdvances = ui->textBoxGeneratorMaxAdvances->getUInt();
     u32 delay = ui->textBoxGeneratorDelay->getUInt();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     EventGenerator4 generator(initialAdvances, maxAdvances, delay, ui->comboBoxGeneratorSpecies->currentIndex() + 1,
                               ui->comboBoxGeneratorNature->currentIndex(), ui->spinBoxGeneratorLevel->value(), *currentProfile, filter);
 
@@ -197,7 +197,7 @@ void Event4::search()
     u32 minAdvance = ui->textBoxSearcherMinAdvance->getUInt();
     u32 maxAdvance = ui->textBoxSearcherMaxAdvance->getUInt();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     auto *searcher = new EventSearcher4(minAdvance, maxAdvance, minDelay, maxDelay, *currentProfile, filter);
 
     int maxProgress = 1;

--- a/Source/Form/Gen4/Static4.cpp
+++ b/Source/Form/Gen4/Static4.cpp
@@ -58,8 +58,8 @@ Static4::Static4(QWidget *parent) : QWidget(parent), ui(new Ui::Static4)
     ui->textBoxSearcherMinAdvance->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvance->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots);
-    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
+    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"), { tr("♂ Lead"), tr("♀ Lead") },
@@ -163,7 +163,7 @@ void Static4::generate()
     u32 delay = ui->textBoxGeneratorDelay->getUInt();
     auto lead = ui->comboMenuGeneratorLead->getEnum<Lead>();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     StaticGenerator4 generator(initialAdvances, maxAdvances, delay, staticTemplate->getMethod(), lead, *staticTemplate, *currentProfile,
                                filter);
 
@@ -258,7 +258,7 @@ void Static4::search()
     const StaticTemplate4 *staticTemplate
         = Encounters4::getStaticEncounter(ui->comboBoxSearcherCategory->currentIndex(), ui->comboBoxSearcherPokemon->getCurrentInt());
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     auto *searcher
         = new StaticSearcher4(minAdvance, maxAdvance, minDelay, maxDelay, staticTemplate->getMethod(), lead, *currentProfile, filter);
 

--- a/Source/Form/Gen4/Wild4.cpp
+++ b/Source/Form/Gen4/Wild4.cpp
@@ -61,7 +61,8 @@ Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
     ui->textBoxSearcherMinAdvance->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvance->setValues(InputType::Advance32Bit);
 
-    ui->filterSearcher->disableControls(Controls::DisableFilter);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::IgnoreInheritance);
+    ui->filterGenerator->disableControls(Controls::IgnoreInheritance);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addAction(tr("Compound Eyes"), toInt(Lead::CompoundEyes));
@@ -362,7 +363,7 @@ void Wild4::generate()
     bool unownRadio = ui->checkBoxGeneratorRadio->isChecked() && ui->comboBoxGeneratorRadio->currentIndex() == 2;
     u8 happiness = ui->comboBoxGeneratorHappiness->getCurrentUChar();
 
-    auto filter = ui->filterGenerator->getFilter<WildStateFilter, true>();
+    auto filter = ui->filterGenerator->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     WildGenerator4 generator(initialAdvances, maxAdvances, delay, method, lead, feebasTile, chained, unownRadio, happiness,
                              encounterGenerator[ui->comboBoxGeneratorLocation->getCurrentInt()], *currentProfile, filter);
 
@@ -710,7 +711,7 @@ void Wild4::search()
     bool unownRadio = ui->checkBoxSearcherRadio->isChecked() && ui->comboBoxSearcherRadio->currentIndex() == 2;
     u8 happiness = ui->comboBoxSearcherHappiness->getCurrentUChar();
 
-    auto filter = ui->filterSearcher->getFilter<WildStateFilter, true>();
+    auto filter = ui->filterSearcher->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     auto *searcher = new WildSearcher4(minAdvance, maxAdvance, minDelay, maxDelay, method, lead, feebas, shiny, unownRadio, happiness, area,
                                        *currentProfile, filter);
 

--- a/Source/Form/Gen5/DreamRadar.cpp
+++ b/Source/Form/Gen5/DreamRadar.cpp
@@ -108,8 +108,8 @@ DreamRadar::DreamRadar(QWidget *parent) : QWidget(parent), ui(new Ui::DreamRadar
     ui->textBoxSearcherInitialAdvances->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvances->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots);
-    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
+    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     ui->comboBoxGeneratorSpecie1->enableAutoComplete();
     ui->comboBoxGeneratorSpecie2->enableAutoComplete();
@@ -301,7 +301,7 @@ void DreamRadar::generate()
     u32 initialAdvances = ui->textBoxGeneratorInitialAdvances->getUInt();
     u32 maxAdvances = ui->textBoxGeneratorMaxAdvances->getUInt();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     DreamRadarGenerator generator(initialAdvances, maxAdvances, ui->spinBoxGeneratorBadges->value(), radarTemplates, *currentProfile,
                                   filter);
 
@@ -336,7 +336,7 @@ void DreamRadar::search()
     u32 initialAdvances = ui->textBoxSearcherInitialAdvances->getUInt();
     u32 maxAdvances = ui->textBoxSearcherMaxAdvances->getUInt();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     DreamRadarGenerator generator(initialAdvances, maxAdvances, ui->spinBoxSearcherBadges->value(), radarTemplates, *currentProfile,
                                   filter);
     auto *searcher = new Searcher5<DreamRadarGenerator, DreamRadarState>(generator, *currentProfile);

--- a/Source/Form/Gen5/Eggs5.cpp
+++ b/Source/Form/Gen5/Eggs5.cpp
@@ -139,7 +139,7 @@ void Eggs5::generate()
     u32 delay = ui->textBoxGeneratorDelay->getUInt();
     Daycare daycare = ui->eggSettingsGenerator->getDaycare();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator5 generator(initialAdvances, maxAdvances, delay, daycare, *currentProfile, filter);
 
     auto states = generator.generate(seed);
@@ -178,7 +178,7 @@ void Eggs5::search()
     u32 maxAdvances = ui->textBoxSearcherMaxAdvances->getUInt();
     Daycare daycare = ui->eggSettingsSearcher->getDaycare();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator5 generator(initialAdvances, maxAdvances, 0, daycare, *currentProfile, filter);
     auto *searcher = new Searcher5<EggGenerator5, EggState5>(generator, *currentProfile);
 

--- a/Source/Form/Gen5/Event5.cpp
+++ b/Source/Form/Gen5/Event5.cpp
@@ -66,8 +66,8 @@ Event5::Event5(QWidget *parent) : QWidget(parent), ui(new Ui::Event5)
         ui->comboBoxSearcherNature->addItem(QString::fromStdString(nature));
     }
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots);
-    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
+    ui->filterSearcher->disableControls(Controls::EncounterSlots | Controls::DisableFilter | Controls::IgnoreInheritance);
 
     ui->filterGenerator->enableHiddenAbility();
     ui->filterSearcher->enableHiddenAbility();
@@ -179,7 +179,7 @@ void Event5::generate()
     u32 delay = ui->textBoxGeneratorDelay->getUInt();
     PGF pgf = getGeneratorParameters();
 
-    auto filter = ui->filterGenerator->getFilter<StateFilter>();
+    auto filter = ui->filterGenerator->getFilter<StateFilter, FILTER_STATE_FILTER>();
     EventGenerator5 generator(initialAdvances, maxAdvances, delay, pgf, *currentProfile, filter);
 
     auto states = generator.generate(seed);
@@ -300,7 +300,7 @@ void Event5::search()
     u32 maxAdvances = ui->textBoxSearcherMaxAdvances->getUInt();
     PGF pgf = getSearcherParameters();
 
-    auto filter = ui->filterSearcher->getFilter<StateFilter>();
+    auto filter = ui->filterSearcher->getFilter<StateFilter, FILTER_STATE_FILTER>();
     EventGenerator5 generator(initialAdvances, maxAdvances, 0, pgf, *currentProfile, filter);
     auto *searcher = new Searcher5<EventGenerator5, State5>(generator, *currentProfile);
 

--- a/Source/Form/Gen8/Eggs8.cpp
+++ b/Source/Form/Gen8/Eggs8.cpp
@@ -136,7 +136,7 @@ void Eggs8::generate()
     }
     Daycare daycare = ui->eggSettings->getDaycare();
 
-    auto filter = ui->filter->getFilter<StateFilter>();
+    auto filter = ui->filter->getFilter<DaycareFilter, FILTER_DAYCARE_FILTER>();
     EggGenerator8 generator(initialAdvances, maxAdvances, delay, compatability, daycare, *currentProfile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Source/Form/Gen8/Event8.cpp
+++ b/Source/Form/Gen8/Event8.cpp
@@ -48,7 +48,7 @@ Event8::Event8(QWidget *parent) : QWidget(parent), ui(new Ui::Event8)
     ui->textBoxEC->setValues(InputType::Seed32Bit);
     ui->textBoxPID->setValues(InputType::Seed32Bit);
 
-    ui->filter->disableControls(Controls::EncounterSlots);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
 
     ui->filter->enableHiddenAbility();
 
@@ -191,7 +191,7 @@ void Event8::generate()
     u32 delay = ui->textBoxDelay->getUInt();
     WB8 wb8 = getParameters();
 
-    auto filter = ui->filter->getFilter<StateFilter>();
+    auto filter = ui->filter->getFilter<StateFilter, FILTER_STATE_FILTER>();
     EventGenerator8 generator(initialAdvances, maxAdvances, delay, wb8, *currentProfile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Source/Form/Gen8/Raids.cpp
+++ b/Source/Form/Gen8/Raids.cpp
@@ -41,7 +41,7 @@ Raids::Raids(QWidget *parent) : QWidget(parent), ui(new Ui::Raids), currentProfi
     model = new RaidModel(ui->tableView);
     ui->tableView->setModel(model);
 
-    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers | Controls::IgnoreInheritance);
     ui->filter->enableHiddenAbility();
 
     ui->comboBoxAbilityType->setItemData(0, 0);
@@ -175,7 +175,7 @@ void Raids::generate()
     u64 seed = ui->textBoxSeed->getULong();
     u8 level = ui->spinBoxLevel->value();
 
-    auto filter = ui->filter->getFilter<StateFilter>();
+    auto filter = ui->filter->getFilter<StateFilter, FILTER_STATE_FILTER>();
     RaidGenerator generator(initialAdvances, maxAdvances, delay, *currentProfile, filter);
 
     if (ui->comboBoxLocation->currentIndex() == 3)

--- a/Source/Form/Gen8/Static8.cpp
+++ b/Source/Form/Gen8/Static8.cpp
@@ -53,7 +53,7 @@ Static8::Static8(QWidget *parent) : QWidget(parent), ui(new Ui::Static8)
     ui->comboBoxShiny->setup({ toInt(Shiny::Never), toInt(Shiny::Random) });
     ui->comboBoxAbility->setup({ 0, 1, 2, 255 });
 
-    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers | Controls::IgnoreInheritance);
 
     connect(ui->comboBoxProfiles, &QComboBox::currentIndexChanged, this, &Static8::profileIndexChanged);
     connect(ui->pushButtonGenerate, &QPushButton::clicked, this, &Static8::generate);
@@ -148,7 +148,7 @@ void Static8::generate()
     const StaticTemplate8 *staticTemplate
         = Encounters8::getStaticEncounter(ui->comboBoxCategory->currentIndex(), ui->comboBoxPokemon->getCurrentInt());
 
-    auto filter = ui->filter->getFilter<StateFilter>();
+    auto filter = ui->filter->getFilter<StateFilter, FILTER_STATE_FILTER>();
     StaticGenerator8 generator(initialAdvances, maxAdvances, delay, lead, *staticTemplate, *currentProfile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Source/Form/Gen8/Underground.cpp
+++ b/Source/Form/Gen8/Underground.cpp
@@ -56,7 +56,7 @@ Underground::Underground(QWidget *parent) : QWidget(parent), ui(new Ui::Undergro
                                { toInt(Lead::Hustle), toInt(Lead::Pressure), toInt(Lead::VitalSpirit) });
     ui->comboMenuLead->addMenu(tr("Synchronize"), Translator::getNatures());
 
-    ui->filter->disableControls(Controls::EncounterSlots);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::IgnoreInheritance);
 
     ui->comboBoxLocation->enableAutoComplete();
 

--- a/Source/Form/Gen8/Wild8.cpp
+++ b/Source/Form/Gen8/Wild8.cpp
@@ -64,6 +64,8 @@ Wild8::Wild8(QWidget *parent) : QWidget(parent), ui(new Ui::Wild8)
 
     ui->comboBoxLocation->enableAutoComplete();
 
+    ui->filter->disableControls(Controls::IgnoreInheritance);
+
     connect(ui->comboBoxProfiles, &QComboBox::currentIndexChanged, this, &Wild8::profileIndexChanged);
     connect(ui->pushButtonGenerate, &QPushButton::clicked, this, &Wild8::generate);
     connect(ui->comboBoxEncounter, &QComboBox::currentIndexChanged, this, &Wild8::encounterIndexChanged);
@@ -210,7 +212,7 @@ void Wild8::generate()
     u32 delay = ui->textBoxDelay->getUInt();
     auto lead = ui->comboMenuLead->getEnum<Lead>();
 
-    auto filter = ui->filter->getFilter<WildStateFilter, true>();
+    auto filter = ui->filter->getFilter<WildStateFilter, FILTER_WILD_FILTER>();
     WildGenerator8 generator(initialAdvances, maxAdvances, delay, lead, encounters[ui->comboBoxLocation->getCurrentInt()], *currentProfile,
                              filter);
 


### PR DESCRIPTION
Adds a third filter class DaycareFilter that each of the egg tabs now use, which has the option to ignore inherited stats for the purposes of filtering the results. 

The primary utility I see for this feature is to make it so that searches for targets do not explicitly depend on the provided values of the parent IVs and instead provides a blueprint for what the parent IVs need to be to match the filters. This allows for a workflow pattern of identifying a target -> identifying parent targets to allow you to hit said target -> getting target parents/egg.  

It also has some utility in gen 3 where there is an incomplete enumeration of the possible VBlank signatures, and therefore even if the user provides all the correct information for an egg they produced,  they may not get a hit on any of the provided methods.