### PR TITLE
Avoid compilation issue w/ Qt6 versions < 6.8

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -94,6 +94,7 @@ int main(int argc, char *argv[])
     QString profilePath = setting.value("profiles").toString();
     bool profile = ProfileLoader::init(profilePath.toStdWString());
 
+#if QT_VERSION > QT_VERSION_CHECK(6, 8, 0)
     a.setStyle("fusion");
     if (setting.value("style").toString() == "dark")
     {
@@ -105,6 +106,15 @@ int main(int argc, char *argv[])
         auto hints = a.styleHints();
         hints->setColorScheme(Qt::ColorScheme::Light);
     }
+#else
+    QFile file(QString(":/qdarkstyle/%1/%1style.qss").arg(setting.value("style").toString()));
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        QTextStream ts(&file);
+        a.setStyleSheet(ts.readAll());
+    }
+
+#endif
 
     QString locale = setting.value("locale").toString();
     Translator::init(locale.toStdString());


### PR DESCRIPTION
Qt 6.8 is not available on MacOS via brew at the time so the code won't compile. I added a simple feature gate to use the old implementation of style. It compiles for me but I'm not 100% sure if it will actually function as intended since I don't know much about the themes in Qt or this codebase generally.