### PR TITLE
Update macOS runner version

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   ci:
     name: Build 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
macOS 12 was deprecated and no longer supported by Apple. This updates to the lowest supported version: 13.