### PR TITLE
PokeFinderCore Build Fixes

### DIFF
--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -272,5 +272,5 @@ add_library(PokeFinderCore STATIC
     Util/Utilities.hpp
 )
 
-target_include_directories(PokeFinderCore PUBLIC "External/fph" "External/nlohmann")
+target_include_directories(PokeFinderCore PUBLIC "External/fph" "External/nlohmann" "../../Source")
 target_link_libraries(PokeFinderCore bz2_static)

--- a/Source/Core/RNG/SHA1.cpp
+++ b/Source/Core/RNG/SHA1.cpp
@@ -23,6 +23,7 @@
 #include <Core/Gen5/Profile5.hpp>
 #include <Core/RNG/LCRNG64.hpp>
 #include <Core/Util/DateTime.hpp>
+#include <algorithm>
 #include <bit>
 
 static u32 calcW(u32 *data, int i)


### PR DESCRIPTION
When trying to build PokeFinderCore on its own, it complains about any includes that start with "<Core/". This is fixed by adding the Source folder to its includes in its CMakeLists. I don't know CMake so I don't know if this is the best way to do this but it seem to work. This also adds ``#include <algorithm>`` to SHA1.cpp since it wouldn't compile without it.