### PR TITLE
Split Emerald Egg in two tables

### DIFF
--- a/Core/Gen3/Generators/EggGenerator3.cpp
+++ b/Core/Gen3/Generators/EggGenerator3.cpp
@@ -175,28 +175,10 @@ EggGenerator3::EggGenerator3(u32 initialAdvances, u32 maxAdvances, u32 offset, u
     }
 }
 
-std::vector<EggState3> EggGenerator3::generate(u32 seedHeld, u32 seedPickup) const
+std::vector<EggState3> EggGenerator3::generateRSFRLG(u32 seedHeld, u32 seedPickup) const
 {
-    switch (method)
-    {
-    case Method::EBred:
-    case Method::EBredSplit:
-    case Method::EBredAlternate:
-    {
-        auto held = generateEmeraldHeld();
-        return held.empty() ? held : generateEmeraldPickup(held);
-    }
-    case Method::RSFRLGBredSplit:
-    case Method::RSFRLGBred:
-    case Method::RSFRLGBredAlternate:
-    case Method::RSFRLGBredMixed:
-    {
-        auto held = generateRSFRLGHeld(seedHeld);
-        return held.empty() ? held : generateRSFRLGPickup(seedPickup, held);
-    }
-    default:
-        return std::vector<EggState3>();
-    }
+    auto held = generateRSFRLGHeld(seedHeld);
+    return held.empty() ? held : generateRSFRLGPickup(seedPickup, held);
 }
 
 std::vector<EggState3> EggGenerator3::generateEmeraldHeld() const
@@ -286,28 +268,20 @@ std::vector<EggState3> EggGenerator3::generateEmeraldHeld() const
 
             EggState3 state(initialAdvances + cnt - offset, redraw, pid, Utilities::getGender(pid, info),
                             Utilities::getShiny<true>(pid, tsv), info);
-            if (filter.compareAbility(state.getAbility()) && filter.compareGender(state.getGender()))
+            if (filter.compareNature(state.getNature()) && filter.compareShiny(state.getShiny()) && filter.compareAbility(state.getAbility()) && filter.compareGender(state.getGender()))
             {
                 states.emplace_back(state);
             }
         }
     }
 
+    std::sort(states.begin(), states.end(), compare);
     return states;
 }
 
-std::vector<EggState3> EggGenerator3::generateEmeraldPickup(const std::vector<EggState3> &held) const
+std::vector<EggState3> EggGenerator3::generateEmeraldPickup() const
 {
     const PersonalInfo *base = PersonalLoader::getPersonal(profile.getVersion(), daycare.getEggSpecie());
-    const PersonalInfo *male = nullptr;
-    if (daycare.getEggSpecie() == 29) // Nidoran
-    {
-        male = PersonalLoader::getPersonal(profile.getVersion(), 32);
-    }
-    else if (daycare.getEggSpecie() == 314) // Illumise
-    {
-        male = PersonalLoader::getPersonal(profile.getVersion(), 313);
-    }
 
     PokeRNG rng(0, initialAdvancesPickup + offsetPickup);
 
@@ -344,24 +318,14 @@ std::vector<EggState3> EggGenerator3::generateEmeraldPickup(const std::vector<Eg
         std::array<u8, 6> inheritance = { 0, 0, 0, 0, 0, 0 };
         setInheritance<true>(daycare, ivs, inheritance, inh, par);
 
-        for (auto state : held)
+        // Empty values since these won't be shown in the Pickup table
+        EggState3 state(0, 0, 0, 0, 0, base);
+        state.update(initialAdvancesPickup + cnt, ivs, inheritance, base);
+        if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareIV(state.getIVs()))
         {
-            const PersonalInfo *info = base;
-            if (male && (state.getPID() & 0x8000))
-            {
-                info = male;
-            }
-
-            state.update(initialAdvancesPickup + cnt, ivs, inheritance, info);
-            if (filter.compareHiddenPower(state.getHiddenPower()) && filter.compareNature(state.getNature())
-                && filter.compareShiny(state.getShiny()) && filter.compareIV(state.getIVs()))
-            {
-                states.emplace_back(state);
-            }
+            states.emplace_back(state);
         }
     }
-
-    std::sort(states.begin(), states.end(), compare);
     return states;
 }
 

--- a/Core/Gen3/Generators/EggGenerator3.hpp
+++ b/Core/Gen3/Generators/EggGenerator3.hpp
@@ -62,18 +62,7 @@ public:
      *
      * @return Vector of computed states
      */
-    std::vector<EggState3> generate(u32 seedHeld = 0, u32 seedPickup = 0) const;
-
-private:
-    u32 initialAdvancesPickup;
-    u32 maxAdvancesPickup;
-    u32 offsetPickup;
-    u8 calibration;
-    u8 inh;
-    u8 iv1;
-    u8 iv2;
-    u8 maxRedraw;
-    u8 minRedraw;
+    std::vector<EggState3> generateRSFRLG(u32 seedHeld = 0, u32 seedPickup = 0) const;
 
     /**
      * @brief Generates states for when the daycare man has the egg
@@ -85,11 +74,20 @@ private:
     /**
      * @brief Generates states for picking up the egg from the daycare man
      *
-     * @param held Vector of held states
-     *
      * @return Vector of computed pickup states
      */
-    std::vector<EggState3> generateEmeraldPickup(const std::vector<EggState3> &held) const;
+    std::vector<EggState3> generateEmeraldPickup() const;
+
+private:
+    u32 initialAdvancesPickup;
+    u32 maxAdvancesPickup;
+    u32 offsetPickup;
+    u8 calibration;
+    u8 inh;
+    u8 iv1;
+    u8 iv2;
+    u8 maxRedraw;
+    u8 minRedraw;
 
     /**
      * @brief Generates states for when the daycare man has the egg

--- a/Form/Gen3/Eggs3.cpp
+++ b/Form/Gen3/Eggs3.cpp
@@ -29,6 +29,8 @@
 #include <Form/Controls/Controls.hpp>
 #include <Form/Gen3/Profile/ProfileManager3.hpp>
 #include <Model/Gen3/EggModel3.hpp>
+#include <Model/Gen3/EggModelEmeraldIVs.hpp>
+#include <Model/Gen3/EggModelEmeraldPID.hpp>
 #include <QMessageBox>
 #include <QSettings>
 
@@ -37,8 +39,11 @@ Eggs3::Eggs3(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs3)
     ui->setupUi(this);
     setAttribute(Qt::WA_QuitOnClose, false);
 
-    emerald = new EggModel3(ui->tableViewEmerald, true);
-    ui->tableViewEmerald->setModel(emerald);
+    emeraldPID = new EggModelEmeraldPID(ui->tableViewEmeraldPID);
+    ui->tableViewEmeraldPID->setModel(emeraldPID);
+
+    emeraldIVs = new EggModelEmeraldIVs(ui->tableViewEmeraldIVs);
+    ui->tableViewEmeraldIVs->setModel(emeraldIVs);
 
     rsfrlg = new EggModel3(ui->tableViewRSFRLG, false);
     ui->tableViewRSFRLG->setModel(rsfrlg);
@@ -78,9 +83,9 @@ Eggs3::Eggs3(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs3)
     connect(ui->pushButtonEmeraldGenerate, &QPushButton::clicked, this, &Eggs3::emeraldGenerate);
     connect(ui->pushButtonRSFRLGGenerate, &QPushButton::clicked, this, &Eggs3::rsfrlgGenerate);
     connect(ui->pushButtonProfileManager, &QPushButton::clicked, this, &Eggs3::profileManager);
-    connect(ui->eggSettingsEmerald, &EggSettings::showInheritanceChanged, emerald, &EggModel3::setShowInheritance);
+    connect(ui->eggSettingsEmerald, &EggSettings::showInheritanceChanged, emeraldIVs, &EggModelEmeraldIVs::setShowInheritance);
     connect(ui->eggSettingsRSFRLG, &EggSettings::showInheritanceChanged, rsfrlg, &EggModel3::setShowInheritance);
-    connect(ui->filterEmerald, &Filter::showStatsChanged, emerald, &EggModel3::setShowStats);
+    connect(ui->filterEmerald, &Filter::showStatsChanged, emeraldIVs, &EggModelEmeraldIVs::setShowStats);
     connect(ui->filterRSFRLG, &Filter::showStatsChanged, rsfrlg, &EggModel3::setShowStats);
 
     updateProfiles();
@@ -136,7 +141,8 @@ void Eggs3::emeraldGenerate()
         return;
     }
 
-    emerald->clearModel();
+    emeraldPID->clearModel();
+    emeraldIVs->clearModel();
 
     u32 initialAdvancesHeld = ui->textBoxEmeraldInitialAdvancesHeld->getUInt();
     u32 maxAdvancesHeld = ui->textBoxEmeraldMaxAdvancesHeld->getUInt();
@@ -156,8 +162,8 @@ void Eggs3::emeraldGenerate()
                             calibration, minRedraw, maxRedraw, method, compatability, ui->eggSettingsEmerald->getDaycare(), *currentProfile,
                             filter);
 
-    auto states = generator.generate();
-    emerald->addItems(states);
+    emeraldPID->addItems(generator.generateEmeraldHeld());
+    emeraldIVs->addItems(generator.generateEmeraldPickup());
 }
 
 void Eggs3::rsfrlgGenerate()
@@ -189,7 +195,7 @@ void Eggs3::rsfrlgGenerate()
     EggGenerator3 generator(initialAdvancesHeld, maxAdvancesHeld, offsetHeld, initialAdvancesPickup, maxAdvancesPickup, offsetPickup, 0, 0,
                             0, method, compatability, ui->eggSettingsRSFRLG->getDaycare(), *currentProfile, filter);
 
-    auto states = generator.generate(ui->textBoxRSFRLGSeedHeld->getUInt(), ui->textBoxRSFRLGSeedPickup->getUInt());
+    auto states = generator.generateRSFRLG(ui->textBoxRSFRLGSeedHeld->getUInt(), ui->textBoxRSFRLGSeedPickup->getUInt());
     rsfrlg->addItems(states);
 }
 

--- a/Form/Gen3/Eggs3.hpp
+++ b/Form/Gen3/Eggs3.hpp
@@ -22,6 +22,8 @@
 
 #include <QWidget>
 
+class EggModelEmeraldIVs;
+class EggModelEmeraldPID;
 class EggModel3;
 class Profile3;
 
@@ -64,7 +66,8 @@ public slots:
 private:
     Ui::Eggs3 *ui;
 
-    EggModel3 *emerald;
+    EggModelEmeraldPID *emeraldPID;
+    EggModelEmeraldIVs *emeraldIVs;
     EggModel3 *rsfrlg;
     Profile3 *currentProfile;
     std::vector<Profile3> profiles;

--- a/Form/Gen3/Eggs3.ui
+++ b/Form/Gen3/Eggs3.ui
@@ -96,7 +96,7 @@
        <string>Emerald</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_17">
-       <item row="0" column="0">
+       <item row="0" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBoxEmeraldRNGInfo">
          <property name="title">
           <string>RNG Info</string>
@@ -254,7 +254,7 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="0" column="2" colspan="2">
         <widget class="QGroupBox" name="groupBoxEmeraldSettings">
          <property name="title">
           <string>Settings</string>
@@ -266,7 +266,7 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="2">
+       <item row="0" column="4" colspan="2">
         <widget class="QGroupBox" name="groupBoxEmeraldFilters">
          <property name="title">
           <string>Filters</string>
@@ -279,7 +279,10 @@
         </widget>
        </item>
        <item row="1" column="0" colspan="3">
-        <widget class="TableView" name="tableViewEmerald"/>
+        <widget class="TableView" name="tableViewEmeraldPID"/>
+       </item>
+       <item row="1" column="3" colspan="3">
+        <widget class="TableView" name="tableViewEmeraldIVs"/>
        </item>
       </layout>
      </widget>
@@ -515,7 +518,8 @@
   <tabstop>comboBoxEmeraldMethod</tabstop>
   <tabstop>comboBoxEmeraldCompatibility</tabstop>
   <tabstop>pushButtonEmeraldGenerate</tabstop>
-  <tabstop>tableViewEmerald</tabstop>
+  <tabstop>tableViewEmeraldPID</tabstop>
+  <tabstop>tableViewEmeraldIVs</tabstop>
   <tabstop>textBoxRSFRLGSeedHeld</tabstop>
   <tabstop>textBoxRSFRLGSeedPickup</tabstop>
   <tabstop>textBoxRSFRLGInitialAdvancesHeld</tabstop>

--- a/Model/CMakeLists.txt
+++ b/Model/CMakeLists.txt
@@ -7,6 +7,10 @@ add_library(PokeFinderModel STATIC
     Gen3/IDModel3.hpp
     Gen3/EggModel3.cpp
     Gen3/EggModel3.hpp
+    Gen3/EggModelEmeraldPID.cpp
+    Gen3/EggModelEmeraldPID.hpp
+    Gen3/EggModelEmeraldIVs.cpp
+    Gen3/EggModelEmeraldIVs.hpp
     Gen3/GameCubeModel.cpp
     Gen3/GameCubeModel.hpp
     Gen3/PIDToIVModel.cpp

--- a/Model/Gen3/EggModelEmeraldIVs.cpp
+++ b/Model/Gen3/EggModelEmeraldIVs.cpp
@@ -1,0 +1,121 @@
+/*
+* This file is part of PokéFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "EggModelEmeraldIVs.hpp"
+
+#include <Core/Util/Translator.hpp>
+
+EggModelEmeraldIVs::EggModelEmeraldIVs(QObject *parent)
+    : TableModel(parent)
+    , showInheritance(false)
+    , showStats(false)
+{
+}
+
+int EggModelEmeraldIVs::columnCount(const QModelIndex &parent) const
+{
+    return static_cast<int>(Column::Count);
+}
+
+QVariant EggModelEmeraldIVs::data(const QModelIndex &index, int role) const
+{
+    if (role == Qt::DisplayRole)
+    {
+        const auto &state = model[index.row()];
+        int column = index.column();
+        switch (static_cast<Column>(column))
+        {
+        case Column::Advances:
+            return state.getPickupAdvances();
+        case Column::HP:
+        case Column::Attack:
+        case Column::Defense:
+        case Column::SpAttack:
+        case Column::SpDefense:
+        case Column::Speed:
+            if (showInheritance)
+            {
+                u8 inh = state.getInheritance(column - static_cast<int>(Column::HP));
+                if (inh)
+                {
+                    return inh == 1 ? "A" : "B";
+                }
+            }
+            return showStats
+                ? state.getStat(column - static_cast<int>(Column::HP))
+                : state.getIV(column - static_cast<int>(Column::HP));
+        case Column::HiddenPowerType:
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+        case Column::HiddenPowerStrength:
+            return state.getHiddenPowerStrength();
+        default:
+            break;
+        }
+    }
+
+    return {};
+}
+QVariant EggModelEmeraldIVs::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
+    {
+        return getColumnName(section);
+    }
+    return {};
+}
+
+QString EggModelEmeraldIVs::getColumnName(int columnIndex)
+{
+    switch (static_cast<Column>(columnIndex))
+    {
+    case Column::Advances:
+        return tr("Pickup Advances");
+    case Column::HP:
+        return tr("HP");
+    case Column::Attack:
+        return tr("Atk");
+    case Column::Defense:
+        return tr("Def");
+    case Column::SpAttack:
+        return tr("SpA");
+    case Column::SpDefense:
+        return tr("SpD");
+    case Column::Speed:
+        return tr("Spe");
+    case Column::HiddenPowerType:
+        return tr("Hidden");
+    case Column::HiddenPowerStrength:
+        return tr("Power");
+    default:
+        return {};
+    }
+}
+
+void EggModelEmeraldIVs::setShowInheritance(bool flag)
+{
+    showInheritance = flag;
+    emit dataChanged(index(0, static_cast<int>(Column::HP)), index(rowCount() - 1, static_cast<int>(Column::Speed)), { Qt::DisplayRole });
+}
+
+void EggModelEmeraldIVs::setShowStats(bool flag)
+{
+    showStats = flag;
+    emit dataChanged(index(0, static_cast<int>(Column::HP)), index(rowCount() - 1, static_cast<int>(Column::Speed)), { Qt::DisplayRole });
+
+}

--- a/Model/Gen3/EggModelEmeraldIVs.hpp
+++ b/Model/Gen3/EggModelEmeraldIVs.hpp
@@ -1,0 +1,111 @@
+/*
+* This file is part of PokéFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef EGGMODELEMERALDIVS_HPP
+#define EGGMODELEMERALDIVS_HPP
+
+#include <Core/Gen3/States/EggState3.hpp>
+#include <Model/TableModel.hpp>
+
+class EggModelEmeraldIVs : public TableModel<EggState3>
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief Construct a new EggModelEmeraldIVs object
+     *
+     * @param parent Parent object, which takes memory ownership
+     */
+    explicit EggModelEmeraldIVs(QObject *parent);
+
+    /**
+     * @brief Returns the number of columns in the model
+     *
+     * @param parent Unused parent index
+     *
+     * @return Number of columns
+     */
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    /**
+     * @brief Returns data at the \p index with \p role
+     *
+     * @param index Row/column index
+     * @param role Model data role
+     *
+     * @return Data at index
+     */
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Returns header text at the \p section, \p orientation, and \p role
+     *
+     * @param section Column index
+     * @param orientation Header position
+     * @param role Model data role
+     *
+     * @return Header text at column
+     */
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+
+public slots:
+    /**
+     * @brief Sets flag that controls whether the model display inheritance or stats/IVs
+     *
+     * @param flag Whether to show inheritance or not
+     */
+    void setShowInheritance(bool flag);
+
+    /**
+     * @brief Sets flag that controls whether the model display stats or IVs
+     *
+     * @param flag Whether to show stats or not
+     */
+    void setShowStats(bool flag);
+
+private:
+    enum class Column
+    {
+        Advances,
+        HP,
+        Attack,
+        Defense,
+        SpAttack,
+        SpDefense,
+        Speed,
+        HiddenPowerType,
+        HiddenPowerStrength,
+
+        Count
+    };
+
+    /**
+     * @brief Returns the name of the given column
+     *
+     * @param columnIndex Column index
+     *
+     * @return Name of the column
+     */
+    static QString getColumnName(int columnIndex);
+
+    bool showInheritance;
+    bool showStats;
+};
+
+#endif // EGGMODELEMERALDIVS_HPP

--- a/Model/Gen3/EggModelEmeraldPID.cpp
+++ b/Model/Gen3/EggModelEmeraldPID.cpp
@@ -1,0 +1,91 @@
+/*
+* This file is part of PokéFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "EggModelEmeraldPID.hpp"
+
+#include <Core/Util/Translator.hpp>
+
+int EggModelEmeraldPID::columnCount(const QModelIndex &parent) const
+{
+    return static_cast<int>(Column::Count);
+}
+
+QVariant EggModelEmeraldPID::data(const QModelIndex &index, int role) const
+{
+    if (role == Qt::DisplayRole)
+    {
+        const auto &state = model[index.row()];
+        switch (static_cast<Column>(index.column()))
+        {
+        case Column::Advances:
+            return state.getAdvances();
+        case Column::Redraws:
+            return state.getRedraws();
+        case Column::PID:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case Column::Shiny:
+        {
+            u8 shiny = state.getShiny();
+            return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
+        }
+        case Column::Nature:
+            return QString::fromStdString(Translator::getNature(state.getNature()));
+        case Column::Ability:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+        case Column::Gender:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        default:
+            break;
+        }
+    }
+
+    return {};
+}
+
+QVariant EggModelEmeraldPID::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
+    {
+        return getColumnName(section);
+    }
+    return {};
+}
+
+QString EggModelEmeraldPID::getColumnName(int columnIndex)
+{
+    switch (static_cast<Column>(columnIndex))
+    {
+    case Column::Advances:
+        return tr("Held Advances");
+    case Column::Redraws:
+        return tr("Redraws");
+    case Column::PID:
+        return tr("PID");
+    case Column::Shiny:
+        return tr("Shiny");
+    case Column::Nature:
+        return tr("Nature");
+    case Column::Ability:
+        return tr("Ability");
+    case Column::Gender:
+        return tr("Gender");
+    default:
+        return {};
+    }
+}

--- a/Model/Gen3/EggModelEmeraldPID.hpp
+++ b/Model/Gen3/EggModelEmeraldPID.hpp
@@ -1,0 +1,86 @@
+/*
+* This file is part of PokéFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef EGGMODELEMERALDPID_HPP
+#define EGGMODELEMERALDPID_HPP
+
+#include <Core/Gen3/States/EggState3.hpp>
+#include <Model/TableModel.hpp>
+
+class EggModelEmeraldPID : public TableModel<EggState3>
+{
+    Q_OBJECT
+public:
+    using TableModel::TableModel;
+
+    /**
+     * @brief Returns the number of columns in the model
+     *
+     * @param parent Unused parent index
+     *
+     * @return Number of columns
+     */
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    /**
+     * @brief Returns data at the \p index with \p role
+     *
+     * @param index Row/column index
+     * @param role Model data role
+     *
+     * @return Data at index
+     */
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    /**
+     * @brief Returns header text at the \p section, \p orientation, and \p role
+     *
+     * @param section Column index
+     * @param orientation Header position
+     * @param role Model data role
+     *
+     * @return Header text at column
+     */
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+
+private:
+    enum class Column
+    {
+        Advances,
+        Redraws,
+        PID,
+        Shiny,
+        Nature,
+        Ability,
+        Gender,
+
+        Count
+    };
+
+    /**
+     * @brief Returns the name of the given column
+     *
+     * @param columnIndex Column index
+     *
+     * @return Name of the column
+     */
+    static QString getColumnName(int columnIndex);
+};
+
+#endif // EGGMODELEMERALDPID_HPP


### PR DESCRIPTION
In Emerald, eggs are created in two stages. Currently, pokefinder does a cartesian product of the two, leading to a crash when generating the table with the default settings, because it's trying to create 25 million rows. I have split the information in two tables, one for the held information (PID, nature, etc) and the other about the pickup information (IVs, hidden power) so that it's more convenient to use.

In my opinion, this also makes the tool easier to understand, since columns are now grouped by when they are populated in-game.

Here's how the table looks:

<img width="1385" height="1144" alt="image" src="https://github.com/user-attachments/assets/15f07016-0eab-40ab-9557-bcf1df746b66" />

I tried to modify as little as possible from the code, hence why I've kept using the same state object for the two tables, `EggState3`. I've had to create new classes for the table model but those aren't very large so hopefully that's okay for you.

I've seen that for the rest of gen 3 games, something similar happens, as in the pokemon are created in two stages, though the information in each stage is different than in Emerald. If you like this change, I could also try and change those tables.

Anyway, please tell me what you think, and what changes you'd make to it!