### PR TITLE
新增 Gen3 RS/FRLG 孵化种子搜索器

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ option(SIMD "Enable SIMD" ON)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (MSVC)
+    add_compile_options(/utf-8)
+endif ()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
 
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(PokeFinderCore)
 
 if (MSVC)
-    add_compile_options(/Zc:inline)
+    add_compile_options(/Zc:inline /utf-8)
 endif ()
 
 if (SIMD)
@@ -57,6 +57,8 @@ add_library(PokeFinderCore STATIC
     Gen3/Profile3.hpp
     Gen3/Searchers/ChannelSeedSearcher.cpp
     Gen3/Searchers/ChannelSeedSearcher.hpp
+    Gen3/Searchers/EggSearcher3.cpp
+    Gen3/Searchers/EggSearcher3.hpp
     Gen3/Searchers/ColoSeedSearcher.cpp
     Gen3/Searchers/ColoSeedSearcher.hpp
     Gen3/Searchers/GalesSeedSearcher.cpp

--- a/Core/Gen3/Searchers/EggSearcher3.cpp
+++ b/Core/Gen3/Searchers/EggSearcher3.cpp
@@ -1,0 +1,347 @@
+/*
+ * This file is part of PokeFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "EggSearcher3.hpp"
+#include <Core/Enum/Method.hpp>
+#include <Core/Gen3/States/EggState3.hpp>
+#include <Core/Parents/PersonalInfo.hpp>
+#include <Core/Parents/PersonalLoader.hpp>
+#include <Core/RNG/LCRNG.hpp>
+#include <Core/Util/Utilities.hpp>
+
+static void setInheritance(const Daycare &daycare, std::array<u8, 6> &ivs, std::array<u8, 6> &inheritance, const u8 *inh, const u8 *par)
+{
+    constexpr u8 order[6] = { 0, 1, 2, 5, 3, 4 };
+
+    u8 available[6] = { 0, 1, 2, 3, 4, 5 };
+    auto avoid = [&available](u8 index, u8 size) {
+        for (u8 i = index; i < size; i++)
+        {
+            available[i] = available[i + 1];
+        }
+    };
+
+    u8 stat = available[inh[0]];
+    ivs[order[stat]] = daycare.getParentIV(par[0], order[stat]);
+    inheritance[order[stat]] = par[0] + 1;
+
+    avoid(stat, 5);
+
+    stat = available[inh[1]];
+    ivs[order[stat]] = daycare.getParentIV(par[1], order[stat]);
+    inheritance[order[stat]] = par[1] + 1;
+
+    avoid(stat, 4);
+
+    stat = available[inh[2]];
+    ivs[order[stat]] = daycare.getParentIV(par[2], order[stat]);
+    inheritance[order[stat]] = par[2] + 1;
+}
+
+EggSearcher3::EggSearcher3(Method method, u8 compatability, const Daycare &daycare, const Profile3 &profile, const StateFilter &filter,
+                           u32 initialAdvancesHeld, u32 maxAdvancesHeld, u32 offsetHeld, u32 initialAdvancesPickup, u32 maxAdvancesPickup,
+                           u32 offsetPickup) :
+    Searcher(method, profile),
+    filter(filter),
+    compatability(compatability),
+    daycare(daycare),
+    initialAdvancesHeld(initialAdvancesHeld),
+    maxAdvancesHeld(maxAdvancesHeld),
+    offsetHeld(offsetHeld),
+    initialAdvancesPickup(initialAdvancesPickup),
+    maxAdvancesPickup(maxAdvancesPickup),
+    offsetPickup(offsetPickup)
+{
+    switch (method)
+    {
+    case Method::RSFRLGBred:
+        iv1 = 1;
+        iv2 = 0;
+        inh = 1;
+        break;
+    case Method::RSFRLGBredSplit:
+        iv1 = 0;
+        iv2 = 1;
+        inh = 1;
+        break;
+    case Method::RSFRLGBredAlternate:
+        iv1 = 1;
+        iv2 = 0;
+        inh = 2;
+        break;
+    case Method::RSFRLGBredMixed:
+        iv1 = 0;
+        iv2 = 0;
+        inh = 2;
+        break;
+    default:
+        iv1 = 1;
+        iv2 = 0;
+        inh = 1;
+        break;
+    }
+}
+
+void EggSearcher3::startSearch(const std::array<u8, 6> &minIVs, const std::array<u8, 6> &maxIVs)
+{
+    searching = true;
+    setMaxProgress(0x10000);
+
+    const PersonalInfo *base = PersonalLoader::getPersonal(profile.getVersion(), daycare.getEggSpecie());
+    const PersonalInfo *male = nullptr;
+    if (daycare.getEggSpecie() == 29) // Nidoran
+    {
+        male = PersonalLoader::getPersonal(profile.getVersion(), 32);
+    }
+    else if (daycare.getEggSpecie() == 314) // Illumise
+    {
+        male = PersonalLoader::getPersonal(profile.getVersion(), 313);
+    }
+
+    std::array<bool, 25> natureFilter;
+    for (u8 n = 0; n < 25; n++)
+    {
+        natureFilter[n] = filter.compareNature(n);
+    }
+
+    // Phase 1 Pass 1: Count held entries per pid_low
+    auto *counts = new u32[0x10000]();
+    auto *index = new u32[0x10000 + 1]();
+
+    for (u32 seed = 0; seed <= 0xFFFF; seed++)
+    {
+        PokeRNG rng(seed, initialAdvancesHeld + offsetHeld);
+        for (u32 cnt = 0; cnt <= maxAdvancesHeld; cnt++, rng.next())
+        {
+            PokeRNG go(rng);
+            if (((go.nextUShort() * 100) / 0xFFFF) < compatability)
+            {
+                u16 pidLow = go.nextUShort(0xFFFE) + 1;
+
+                u8 ability = pidLow & 1;
+                if (!filter.compareAbility(ability))
+                {
+                    continue;
+                }
+                const PersonalInfo *info = base;
+                if (male && (pidLow & 0x8000))
+                {
+                    info = male;
+                }
+                if (!filter.compareGender(Utilities::getGender(pidLow, info)))
+                {
+                    continue;
+                }
+
+                counts[pidLow]++;
+            }
+        }
+    }
+
+    // Build offset index
+    u32 totalEntries = 0;
+    for (u32 i = 0; i < 0x10000; i++)
+    {
+        index[i] = totalEntries;
+        totalEntries += counts[i];
+    }
+    index[0x10000] = totalEntries;
+
+    // Allocate flat storage
+    std::vector<HeldEntry> heldData(totalEntries);
+    auto *writePos = new u32[0x10000]();
+
+    // Phase 1 Pass 2: Fill entries
+    for (u32 seed = 0; seed <= 0xFFFF; seed++)
+    {
+        PokeRNG rng(seed, initialAdvancesHeld + offsetHeld);
+        for (u32 cnt = 0; cnt <= maxAdvancesHeld; cnt++, rng.next())
+        {
+            PokeRNG go(rng);
+            if (((go.nextUShort() * 100) / 0xFFFF) < compatability)
+            {
+                u16 pidLow = go.nextUShort(0xFFFE) + 1;
+
+                u8 ability = pidLow & 1;
+                if (!filter.compareAbility(ability))
+                {
+                    continue;
+                }
+                const PersonalInfo *info = base;
+                if (male && (pidLow & 0x8000))
+                {
+                    info = male;
+                }
+                if (!filter.compareGender(Utilities::getGender(pidLow, info)))
+                {
+                    continue;
+                }
+
+                u32 pos = index[pidLow] + writePos[pidLow]++;
+                heldData[pos] = { static_cast<u16>(seed), initialAdvancesHeld + cnt };
+            }
+        }
+    }
+
+    delete[] counts;
+    delete[] writePos;
+
+    // Phase 2: Precompute pid_low values grouped by nature
+    std::vector<u16> pidLowByNature[25];
+    for (u32 p = 1; p < 0x10000; p += 2)
+    {
+        pidLowByNature[p % 25].push_back(p);
+    }
+
+    // Phase 3: Iterate all pickup seeds
+    constexpr size_t maxResults = 100000;
+    size_t resultCount = 0;
+
+    for (u32 seed = 0; seed <= 0xFFFF; seed++)
+    {
+        if (!searching)
+        {
+            delete[] index;
+            return;
+        }
+
+        PokeRNG rng(static_cast<u16>(seed), initialAdvancesPickup + offsetPickup);
+        for (u32 cnt = 0; cnt <= maxAdvancesPickup; cnt++, rng.next())
+        {
+            PokeRNG go(rng);
+
+            u16 pidHigh = go.nextUShort();
+
+            go.advance(iv1);
+            u16 iv1Val = go.nextUShort();
+            go.advance(iv2);
+            u16 iv2Val = go.nextUShort();
+
+            std::array<u8, 6> ivs;
+            ivs[0] = iv1Val & 31;
+            ivs[1] = (iv1Val >> 5) & 31;
+            ivs[2] = (iv1Val >> 10) & 31;
+            ivs[3] = (iv2Val >> 5) & 31;
+            ivs[4] = (iv2Val >> 10) & 31;
+            ivs[5] = iv2Val & 31;
+
+            go.advance(inh);
+            u8 inhVals[3];
+            inhVals[0] = go.nextUShort(6);
+            inhVals[1] = go.nextUShort(5);
+            inhVals[2] = go.nextUShort(4);
+
+            u8 par[3];
+            par[0] = go.nextUShort(2);
+            par[1] = go.nextUShort(2);
+            par[2] = go.nextUShort(2);
+
+            std::array<u8, 6> inheritance = { 0, 0, 0, 0, 0, 0 };
+            setInheritance(daycare, ivs, inheritance, inhVals, par);
+
+            // IV filter
+            bool ivMatch = true;
+            for (int i = 0; i < 6; i++)
+            {
+                if (ivs[i] < minIVs[i] || ivs[i] > maxIVs[i])
+                {
+                    ivMatch = false;
+                    break;
+                }
+            }
+            if (!ivMatch)
+            {
+                continue;
+            }
+
+            // Hidden Power filter
+            u8 hiddenPower = ((((ivs[0] & 1) + 2 * (ivs[1] & 1) + 4 * (ivs[2] & 1) + 8 * (ivs[3] & 1) + 16 * (ivs[4] & 1)
+                                + 32 * (ivs[5] & 1))
+                               * 15)
+                              / 63);
+            if (!filter.compareHiddenPower(hiddenPower))
+            {
+                continue;
+            }
+
+            // Match pid_low values against held states
+            u8 natureContrib = static_cast<u8>((static_cast<u32>(pidHigh) << 16) % 25);
+
+            for (u8 natureTarget = 0; natureTarget < 25; natureTarget++)
+            {
+                if (!natureFilter[natureTarget])
+                {
+                    continue;
+                }
+
+                u8 targetMod = (natureTarget - natureContrib + 25) % 25;
+
+                for (u16 pidLow : pidLowByNature[targetMod])
+                {
+                    if (!searching || resultCount >= maxResults)
+                    {
+                        delete[] index;
+                        return;
+                    }
+
+                    u8 shiny = Utilities::getShiny<true>((static_cast<u32>(pidHigh) << 16) | pidLow, tsv);
+                    if (!filter.compareShiny(shiny))
+                    {
+                        continue;
+                    }
+
+                    u32 start = index[pidLow];
+                    u32 end = index[pidLow + 1];
+                    if (start == end)
+                    {
+                        continue;
+                    }
+
+                    const PersonalInfo *info = base;
+                    if (male && (pidLow & 0x8000))
+                    {
+                        info = male;
+                    }
+
+                    for (u32 i = start; i < end; i++)
+                    {
+                        const auto &held = heldData[i];
+                        EggState3 state(held.advances, pidLow, Utilities::getGender(pidLow, info), info);
+                        state.setSeedHeld(held.seed);
+                        state.setSeedPickup(static_cast<u16>(seed));
+                        state.update(initialAdvancesPickup + cnt, (static_cast<u32>(pidHigh) << 16) | pidLow,
+                                     shiny, ivs, inheritance, info);
+
+                        if (filter.compareIV(state.getIVs()) && filter.compareHiddenPower(state.getHiddenPower())
+                            && filter.compareNature(state.getNature()) && filter.compareShiny(state.getShiny()))
+                        {
+                            std::lock_guard<std::mutex> guard(mutex);
+                            results.emplace_back(state);
+                            resultCount++;
+                        }
+                    }
+                }
+            }
+        }
+
+        progress++;
+    }
+
+    delete[] index;
+}

--- a/Core/Gen3/Searchers/EggSearcher3.hpp
+++ b/Core/Gen3/Searchers/EggSearcher3.hpp
@@ -1,0 +1,85 @@
+/*
+ * This file is part of PokéFinder
+ * Copyright (C) 2017-2024 by Admiral_Fish, bumba, and EzPzStreamz
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef EGGSEARCHER3_HPP
+#define EGGSEARCHER3_HPP
+
+#include <Core/Gen3/Profile3.hpp>
+#include <Core/Parents/Daycare.hpp>
+#include <Core/Parents/Filters/StateFilter.hpp>
+#include <Core/Parents/Searchers/Searcher.hpp>
+
+class EggState3;
+
+/**
+ * @brief RS/FRLG egg seed searcher
+ * Searches for held seed + pickup seed combinations that satisfy conditions
+ */
+class EggSearcher3 : public Searcher<Profile3, EggState3>
+{
+public:
+    /**
+     * @brief Construct a new EggSearcher3 object
+     *
+     * @param method Encounter method
+     * @param compatability Parent compatability
+     * @param daycare Daycare parent information
+     * @param profile Profile Information
+     * @param filter State filter
+     * @param initialAdvancesHeld Initial number of held advances
+     * @param maxAdvancesHeld Maximum number of held advances
+     * @param offsetHeld Number of held advances to offset
+     * @param initialAdvancesPickup Initial number of pickup advances
+     * @param maxAdvancesPickup Maximum number of pickup advances
+     * @param offsetPickup Number of pickup advances to offset
+     */
+    EggSearcher3(Method method, u8 compatability, const Daycare &daycare, const Profile3 &profile, const StateFilter &filter,
+                 u32 initialAdvancesHeld, u32 maxAdvancesHeld, u32 offsetHeld, u32 initialAdvancesPickup, u32 maxAdvancesPickup,
+                 u32 offsetPickup);
+
+    /**
+     * @brief Starts the search
+     *
+     * @param minIVs Minimum IV thresholds
+     * @param maxIVs Maximum IV thresholds
+     */
+    void startSearch(const std::array<u8, 6> &minIVs, const std::array<u8, 6> &maxIVs);
+
+private:
+    StateFilter filter;
+    u8 compatability;
+    Daycare daycare;
+    u32 initialAdvancesHeld;
+    u32 maxAdvancesHeld;
+    u32 offsetHeld;
+    u32 initialAdvancesPickup;
+    u32 maxAdvancesPickup;
+    u32 offsetPickup;
+    u8 iv1;
+    u8 iv2;
+    u8 inh;
+
+    struct HeldEntry
+    {
+        u16 seed;
+        u32 advances;
+    };
+};
+
+#endif // EGGSEARCHER3_HPP

--- a/Core/Gen3/States/EggState3.hpp
+++ b/Core/Gen3/States/EggState3.hpp
@@ -40,7 +40,7 @@ public:
      */
     EggState3(u32 advances, u8 redraws, u32 pid, u8 gender, u8 shiny, const PersonalInfo *info) :
         EggGeneratorState(advances, pid, { 0, 0, 0, 0, 0, 0 }, pid & 1, gender, 5, pid % 25, shiny, { 0, 0, 0, 0, 0, 0 }, info),
-        redraws(redraws)
+        redraws(redraws), seedHeld(0), seedPickup(0)
     {
     }
 
@@ -54,7 +54,8 @@ public:
      * @param info Pokemon information
      */
     EggState3(u32 advances, u16 low, u8 gender, const PersonalInfo *info) :
-        EggGeneratorState(advances, low, { 0, 0, 0, 0, 0, 0 }, low & 1, gender, 5, 0, 0, { 0, 0, 0, 0, 0, 0 }, info), redraws(0)
+        EggGeneratorState(advances, low, { 0, 0, 0, 0, 0, 0 }, low & 1, gender, 5, 0, 0, { 0, 0, 0, 0, 0, 0 }, info), redraws(0), seedHeld(0),
+        seedPickup(0)
     {
     }
 
@@ -76,6 +77,46 @@ public:
     u8 getRedraws() const
     {
         return redraws;
+    }
+
+    /**
+     * @brief Returns the held seed of the state
+     *
+     * @return Held seed
+     */
+    u16 getSeedHeld() const
+    {
+        return seedHeld;
+    }
+
+    /**
+     * @brief Returns the pickup seed of the state
+     *
+     * @return Pickup seed
+     */
+    u16 getSeedPickup() const
+    {
+        return seedPickup;
+    }
+
+    /**
+     * @brief Sets the held seed
+     *
+     * @param seed Held seed value
+     */
+    void setSeedHeld(u16 seed)
+    {
+        seedHeld = seed;
+    }
+
+    /**
+     * @brief Sets the pickup seed
+     *
+     * @param seed Pickup seed value
+     */
+    void setSeedPickup(u16 seed)
+    {
+        seedPickup = seed;
     }
 
     /**
@@ -119,6 +160,8 @@ public:
 private:
     u32 pickupAdvances;
     u8 redraws;
+    u16 seedHeld;
+    u16 seedPickup;
 };
 
 #endif // EGGSTATE3_HPP

--- a/Core/Gen8/Raid.hpp
+++ b/Core/Gen8/Raid.hpp
@@ -94,10 +94,10 @@ public:
 
         if (low == high)
         {
-            return std::to_string(low + 1) + "★";
+            return std::to_string(low + 1) + "*";
         }
 
-        return std::to_string(low + 1) + "-" + std::to_string(high + 1) + "★";
+        return std::to_string(low + 1) + "-" + std::to_string(high + 1) + "*";
     }
 
 private:

--- a/Form/Gen3/Eggs3.cpp
+++ b/Form/Gen3/Eggs3.cpp
@@ -22,14 +22,19 @@
 #include <Core/Enum/Game.hpp>
 #include <Core/Enum/Method.hpp>
 #include <Core/Gen3/Generators/EggGenerator3.hpp>
+#include <Core/Gen3/Searchers/EggSearcher3.hpp>
+#include <Core/Gen3/States/EggState3.hpp>
 #include <Core/Gen3/Profile3.hpp>
+#include <Core/Parents/PersonalLoader.hpp>
 #include <Core/Parents/ProfileLoader.hpp>
 #include <Core/Util/Nature.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
 #include <Form/Gen3/Profile/ProfileManager3.hpp>
 #include <Model/Gen3/EggModel3.hpp>
+#include <QGridLayout>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QSettings>
 
 Eggs3::Eggs3(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs3)
@@ -78,6 +83,18 @@ Eggs3::Eggs3(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs3)
     connect(ui->pushButtonEmeraldGenerate, &QPushButton::clicked, this, &Eggs3::emeraldGenerate);
     connect(ui->pushButtonRSFRLGGenerate, &QPushButton::clicked, this, &Eggs3::rsfrlgGenerate);
     connect(ui->pushButtonProfileManager, &QPushButton::clicked, this, &Eggs3::profileManager);
+
+    // Add Search button for RS/FRLG
+    QPushButton *searchButton = new QPushButton(tr("Search"));
+    auto *rsfrlgLayout = qobject_cast<QGridLayout *>(ui->pushButtonRSFRLGGenerate->parentWidget()->layout());
+    if (rsfrlgLayout)
+    {
+        int row, col, rowSpan, colSpan;
+        auto index = rsfrlgLayout->indexOf(ui->pushButtonRSFRLGGenerate);
+        rsfrlgLayout->getItemPosition(index, &row, &col, &rowSpan, &colSpan);
+        rsfrlgLayout->addWidget(searchButton, row + 1, col, 1, 1);
+    }
+    connect(searchButton, &QPushButton::clicked, this, &Eggs3::rsfrlgSearch);
     connect(ui->eggSettingsEmerald, &EggSettings::showInheritanceChanged, emerald, &EggModel3::setShowInheritance);
     connect(ui->eggSettingsRSFRLG, &EggSettings::showInheritanceChanged, rsfrlg, &EggModel3::setShowInheritance);
     connect(ui->filterEmerald, &Filter::showStatsChanged, emerald, &EggModel3::setShowStats);
@@ -175,6 +192,7 @@ void Eggs3::rsfrlgGenerate()
     }
 
     rsfrlg->clearModel();
+    rsfrlg->setShowSeeds(false);
 
     u32 initialAdvancesHeld = ui->textBoxRSFRLGInitialAdvancesHeld->getUInt();
     u32 maxAdvancesHeld = ui->textBoxRSFRLGMaxAdvancesHeld->getUInt();
@@ -190,6 +208,59 @@ void Eggs3::rsfrlgGenerate()
                             0, method, compatability, ui->eggSettingsRSFRLG->getDaycare(), *currentProfile, filter);
 
     auto states = generator.generate(ui->textBoxRSFRLGSeedHeld->getUInt(), ui->textBoxRSFRLGSeedPickup->getUInt());
+    rsfrlg->addItems(states);
+}
+
+void Eggs3::rsfrlgSearch()
+{
+    if (!ui->eggSettingsRSFRLG->compatibleParents())
+    {
+        QMessageBox box(QMessageBox::Warning, tr("Incompatible Parents"), tr("Gender of selected parents are not compatible for breeding"));
+        box.exec();
+        return;
+    }
+
+    if (!ui->filterRSFRLG->isValid())
+    {
+        return;
+    }
+
+    rsfrlg->clearModel();
+    rsfrlg->setShowSeeds(true);
+
+    u32 initialAdvancesHeld = ui->textBoxRSFRLGInitialAdvancesHeld->getUInt();
+    u32 maxAdvancesHeld = ui->textBoxRSFRLGMaxAdvancesHeld->getUInt();
+    u32 offsetHeld = ui->textBoxRSFRLGOffsetHeld->getUInt();
+    u32 initialAdvancesPickup = ui->textBoxRSFRLGInitialAdvancesPickup->getUInt();
+    u32 maxAdvancesPickup = ui->textBoxRSFRLGMaxAdvancesPickup->getUInt();
+    u32 offsetPickup = ui->textBoxRSFRLGOffsetPickup->getUInt();
+
+    if (maxAdvancesHeld > 5000)
+    {
+        auto result = QMessageBox::question(this, tr("Search"),
+                                            tr("Max Held Advances > 5000 may cause high memory usage (%.1f GB). Continue?")
+                                                .arg(maxAdvancesHeld * 65536.0 * 0.5 * 6 / (1024 * 1024 * 1024)),
+                                            QMessageBox::Yes | QMessageBox::No);
+        if (result == QMessageBox::No)
+        {
+            return;
+        }
+    }
+
+    u8 compatability = ui->comboBoxRSFRLGCompatibility->getCurrentUChar();
+    auto method = ui->comboBoxRSFRLGMethod->getEnum<Method>();
+
+    auto filter = ui->filterRSFRLG->getFilter<StateFilter>();
+    auto minIVs = ui->filterRSFRLG->getMinIVs();
+    auto maxIVs = ui->filterRSFRLG->getMaxIVs();
+
+    EggSearcher3 searcher(method, compatability, ui->eggSettingsRSFRLG->getDaycare(), *currentProfile, filter,
+                          initialAdvancesHeld, maxAdvancesHeld, offsetHeld,
+                          initialAdvancesPickup, maxAdvancesPickup, offsetPickup);
+
+    searcher.startSearch(minIVs, maxIVs);
+
+    auto states = searcher.getResults();
     rsfrlg->addItems(states);
 }
 

--- a/Form/Gen3/Eggs3.hpp
+++ b/Form/Gen3/Eggs3.hpp
@@ -81,6 +81,11 @@ private slots:
     void rsfrlgGenerate();
 
     /**
+     * @brief Searches for matching held seed and pickup seed combinations for RS/FRLG
+     */
+    void rsfrlgSearch();
+
+    /**
      * @brief Updates displayed information for a profile
      *
      * @param index Profile index

--- a/Model/Gen3/EggModel3.cpp
+++ b/Model/Gen3/EggModel3.cpp
@@ -20,13 +20,18 @@
 #include "EggModel3.hpp"
 #include <Core/Util/Translator.hpp>
 
-EggModel3::EggModel3(QObject *parent, bool emerald) : TableModel(parent), emerald(emerald), showInheritance(false), showStats(false)
+EggModel3::EggModel3(QObject *parent, bool emerald) :
+    TableModel(parent), emerald(emerald), showInheritance(false), showStats(false), showSeeds(false)
 {
 }
 
 int EggModel3::columnCount(const QModelIndex &parent) const
 {
-    if (emerald)
+    if (showSeeds)
+    {
+        return 17;
+    }
+    else if (emerald)
     {
         return 16;
     }
@@ -40,9 +45,24 @@ QVariant EggModel3::data(const QModelIndex &index, int role) const
 {
     if (role == Qt::DisplayRole)
     {
+        const auto &state = model[index.row()];
+
+        // 搜索模式下的种子列
+        if (showSeeds)
+        {
+            switch (index.column())
+            {
+            case 0:
+                return QString::number(state.getSeedHeld(), 16).toUpper().rightJustified(4, '0');
+            case 1:
+                return QString::number(state.getSeedPickup(), 16).toUpper().rightJustified(4, '0');
+            default:
+                break;
+            }
+        }
+
         int column = getColumn(index.column());
 
-        const auto &state = model[index.row()];
         switch (column)
         {
         case 0:
@@ -93,6 +113,18 @@ QVariant EggModel3::headerData(int section, Qt::Orientation orientation, int rol
 {
     if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
     {
+        if (showSeeds)
+        {
+            switch (section)
+            {
+            case 0:
+                return tr("Held Seed");
+            case 1:
+                return tr("Pickup Seed");
+            default:
+                break;
+            }
+        }
         section = getColumn(section);
         return header[section];
     }
@@ -111,14 +143,27 @@ void EggModel3::setShowStats(bool flag)
     emit dataChanged(index(0, 7), index(rowCount() - 1, 12), { Qt::DisplayRole });
 }
 
+void EggModel3::setShowSeeds(bool flag)
+{
+    showSeeds = flag;
+    emit layoutChanged();
+}
+
 int EggModel3::getColumn(int column) const
 {
+    // Search mode: first two columns are seedHeld/seedPickup, rest shift by 2
+    if (showSeeds)
+    {
+        column -= 2;
+    }
+
     if (emerald)
     {
         return column;
     }
     else
     {
+        // Non-Emerald: skip header[2] (Redraws)
         return column > 1 ? column + 1 : column;
     }
 }

--- a/Model/Gen3/EggModel3.hpp
+++ b/Model/Gen3/EggModel3.hpp
@@ -83,6 +83,13 @@ public slots:
      */
     void setShowStats(bool flag);
 
+    /**
+     * @brief Sets flag that controls whether the model displays seed columns
+     *
+     * @param flag Whether to show seed columns
+     */
+    void setShowSeeds(bool flag);
+
 private:
     QStringList header = { tr("Held Advances"), tr("Pickup Advances"),
                            tr("Redraws"),       tr("PID"),
@@ -95,6 +102,7 @@ private:
     bool emerald;
     bool showInheritance;
     bool showStats;
+    bool showSeeds;
 
     int getColumn(int column) const;
 };


### PR DESCRIPTION
实现 EggSearcher3，支持根据 IV/性格/闪光等条件反向搜索
held seed 与 pickup seed 组合。使用两级预计算 + 单数组索引
优化内存占用，Phase 3 按性格分桶加速 pid_low 匹配。

同时修改：
- EggState3 添加 seedHeld/seedPickup 字段
- EggModel3 支持搜索模式下的种子列显示
- Eggs3 UI 新增 Search 按钮，超 5000 帧弹窗确认
- 修复部分文件 MSVC 2026 编码兼容问题