### PR TITLE
Fix macOS arm64 build failures: SIMD flag scoping, arch guard, ranges::copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.31)
 
-if (APPLE)
+if (APPLE AND NOT DEFINED CMAKE_OSX_ARCHITECTURES)
     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 endif()
 

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -4,21 +4,10 @@ if (MSVC)
     add_compile_options(/Zc:inline)
 endif ()
 
-if (SIMD)
-    add_definitions(-DSIMD)
-
-    if (APPLE)
-        add_compile_options(-msse2 -mssse3 -mavx -mavx2 -mfpu=neon)
-    elseif (MINGW OR UNIX)
-        include(GetTargetArch)
-        get_target_arch(ARCH)
-        if ((ARCH STREQUAL "x86_64") OR (ARCH STREQUAL "i686"))
-            add_compile_options(-msse2 -mssse3 -mavx -mavx2)
-        elseif (ARCH STREQUAL "arm")
-            add_compile_options(-mfpu=neon)
-        endif ()
-    endif ()
-endif()
+if (MINGW OR UNIX)
+    include(GetTargetArch)
+    get_target_arch(ARCH)
+endif ()
 
 find_package(Python3 3.14 COMPONENTS Interpreter REQUIRED)
 execute_process(COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Resources/EncounterTables/main.py)
@@ -277,3 +266,29 @@ add_library(PokeFinderCore STATIC
 
 target_include_directories(PokeFinderCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/External)
 target_link_libraries(PokeFinderCore libzstd_static)
+
+if (SIMD)
+    target_compile_definitions(PokeFinderCore PRIVATE SIMD)
+
+    if (APPLE)
+        if (CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
+            if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+                # Universal binary: scope x86 SIMD flags to the x86_64 slice only.
+                # arm64 always has NEON; -mfpu= is ARMv7-only and must not be passed.
+                # Use SHELL: to prevent CMake from deduplicating the -Xarch_x86_64 pairs.
+                target_compile_options(PokeFinderCore PRIVATE
+                    "SHELL:-Xarch_x86_64 -msse2" "SHELL:-Xarch_x86_64 -mssse3"
+                    "SHELL:-Xarch_x86_64 -mavx" "SHELL:-Xarch_x86_64 -mavx2")
+            else()
+                target_compile_options(PokeFinderCore PRIVATE -msse2 -mssse3 -mavx -mavx2)
+            endif()
+        endif()
+        # arm64-only: NEON is always enabled by default, no explicit flag needed.
+    elseif (MINGW OR UNIX)
+        if ((ARCH STREQUAL "x86_64") OR (ARCH STREQUAL "i686"))
+            target_compile_options(PokeFinderCore PRIVATE -msse2 -mssse3 -mavx -mavx2)
+        elseif (ARCH STREQUAL "arm")
+            target_compile_options(PokeFinderCore PRIVATE -mfpu=neon)
+        endif ()
+    endif ()
+endif()

--- a/Core/RNG/SHA1.cpp
+++ b/Core/RNG/SHA1.cpp
@@ -23,6 +23,7 @@
 #include <Core/Gen5/Profile5.hpp>
 #include <Core/RNG/LCRNG64.hpp>
 #include <Core/Util/DateTime.hpp>
+#include <algorithm>
 #include <bit>
 
 static u32 calcW(u32 *data, int i)
@@ -177,7 +178,7 @@ SHA1::SHA1(const Profile5 &profile) :
 SHA1::SHA1(Game version, Language language, DSType type, u64 mac, u8 vFrame, u8 gxStat)
 {
     auto nazos = Nazos::getNazo(version, language, type);
-    std::copy(nazos.begin(), nazos.end(), data);
+    std::ranges::copy(nazos, data);
 
     data[6] = mac & 0xffff;
     data[7] = static_cast<u32>((mac >> 16) ^ static_cast<u32>(vFrame << 24) ^ gxStat);


### PR DESCRIPTION
## Problem

Building on macOS Apple Silicon (arm64) fails in several ways:

1. **`Core/CMakeLists.txt`** — the SIMD block unconditionally passed `-mfpu=neon` (an ARMv7-only flag) and x86 SSE/AVX flags to all Apple targets, causing clang to error on arm64 (`unsupported option '-mfpu=' for target 'arm64-apple-darwin'`).
2. **`Core/CMakeLists.txt`** — `add_definitions`/`add_compile_options` are directory-scoped and leak SIMD flags into the `External/zstd` subdirectory.
3. **`CMakeLists.txt`** — `set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")` fired unconditionally, ignoring any `-DCMAKE_OSX_ARCHITECTURES` value passed at configure time (e.g. `arm64` for a native Apple Silicon build). Homebrew Qt6 on Apple Silicon is arm64-only, so the universal binary link fails with unresolved x86_64 Qt symbols.
4. **`Core/RNG/SHA1.cpp`** — `std::copy` used without `#include <algorithm>`, which newer Apple Clang/libc++ no longer provides transitively.

## Changes

### `CMakeLists.txt`
- Changed guard from `NOT CMAKE_OSX_ARCHITECTURES` to `NOT DEFINED CMAKE_OSX_ARCHITECTURES` so a user-supplied value (e.g. `-DCMAKE_OSX_ARCHITECTURES=arm64`) is correctly respected instead of being overwritten.

### `Core/CMakeLists.txt`
- Replaced directory-wide `add_definitions(-DSIMD)` / `add_compile_options(...)` with `target_compile_definitions(PokeFinderCore PRIVATE SIMD)` / `target_compile_options(PokeFinderCore PRIVATE ...)` placed after the `add_library` call, so SIMD flags are scoped to `PokeFinderCore` only.
- Fixed the Apple SIMD flag logic:
  - Universal binary (`x86_64;arm64`): x86 flags wrapped with `SHELL:-Xarch_x86_64` so they apply only to the x86_64 compilation slice.
  - arm64-only: no flags added — NEON is unconditionally available on `__aarch64__` and `-mfpu=neon` is an ARMv7 flag that clang rejects on arm64.

### `Core/RNG/SHA1.cpp`
- Added missing `#include <algorithm>` and modernised `std::copy(nazos.begin(), nazos.end(), data)` to `std::ranges::copy(nazos, data)` per the C++23 idiom used elsewhere in the codebase.

## Related

- Supersedes the `SHA1.cpp` portion of #464 (which also adds `#include <algorithm>` but does not modernise to `std::ranges::copy`).