### PR TITLE
Addition of level searcher

### DIFF
--- a/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
+++ b/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
@@ -148,7 +148,7 @@ std::vector<State5> HiddenGrottoGenerator::generate(u64 seed, const std::vector<
     BWRNG rng(seed, advances + initialAdvances);
     auto jump = rng.getJump(offset);
 
-    u8 range = slot.getMaxLevel() - slot.getMinLevel();
+    u8 range = slot.getMaxLevel() - slot.getMinLevel() + 1;
 
     // Even though hidden grotto can't be shiny it still respects the extra rolls from shiny charm
     // It also respects the extra roll from lucky power but since that choice isn't selectable in the UI we will ignore it

--- a/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
+++ b/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
@@ -148,7 +148,7 @@ std::vector<State5> HiddenGrottoGenerator::generate(u64 seed, const std::vector<
     BWRNG rng(seed, advances + initialAdvances);
     auto jump = rng.getJump(offset);
 
-    u8 range = slot.getMaxLevel() - slot.getMinLevel() + 1;
+    u8 range = slot.getMaxLevel() - slot.getMinLevel();
 
     // Even though hidden grotto can't be shiny it still respects the extra rolls from shiny charm
     // It also respects the extra roll from lucky power but since that choice isn't selectable in the UI we will ignore it

--- a/Core/Gen8/Filters/UndergroundFilter.cpp
+++ b/Core/Gen8/Filters/UndergroundFilter.cpp
@@ -21,11 +21,11 @@
 #include <Core/Gen8/States/UndergroundState.hpp>
 #include <algorithm>
 
-UndergroundStateFilter::UndergroundStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax,
+UndergroundStateFilter::UndergroundStateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax,
                                                bool skip, const std::array<u8, 6> &min, const std::array<u8, 6> &max,
                                                const std::array<bool, 25> &natures, const std::array<bool, 16> &powers,
                                                const std::vector<u16> &species) :
-    StateFilter(gender, ability, shiny, heightMin, heightMax, weightMin, weightMax, skip, min, max, natures, powers), species(species)
+    StateFilter(gender, ability, shiny, levelMin, levelMax, heightMin, heightMax, weightMin, weightMax, skip, min, max, natures, powers), species(species)
 {
     std::ranges::sort(this->species);
 }
@@ -48,6 +48,11 @@ bool UndergroundStateFilter::compareState(const UndergroundState &state) const
     }
 
     if (!natures[state.getNature()])
+    {
+        return false;
+    }
+
+    if (state.getLevel() < levelMin || state.getLevel() > levelMax)
     {
         return false;
     }

--- a/Core/Gen8/Filters/UndergroundFilter.hpp
+++ b/Core/Gen8/Filters/UndergroundFilter.hpp
@@ -37,6 +37,8 @@ public:
      * @param gender Gender value to filter by
      * @param ability Ability value to filter by
      * @param shiny Shiny value to filter by
+     * @param levelMin Minimum level threshold
+     * @param levelMax Maximum level threshold
      * @param heightMin Minimum height threshold
      * @param heightMax Maximum height threshold
      * @param weightMin Minimum weight threshold
@@ -48,7 +50,8 @@ public:
      * @param powers Hidden powers to filter by
      * @param species Pokemon species to filter by
      */
-    UndergroundStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip, const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax,
+    UndergroundStateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin,
+                           u8 weightMax, bool skip, const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax,
                            const std::array<bool, 25> &natures, const std::array<bool, 16> &powers, const std::vector<u16> &species);
 
     /**

--- a/Core/Parents/EncounterArea.cpp
+++ b/Core/Parents/EncounterArea.cpp
@@ -47,6 +47,13 @@ std::pair<u8, u8> EncounterArea::getLevelRange(u16 specie) const
             range.second = std::max(range.second, pokemon[i].getMaxLevel());
         }
     }
+
+    // Zero out range if we don't have a matching pokemon
+    if (range.first == 100 && range.second == 0)
+    {
+        range.first = 0;
+    }
+
     return range;
 }
 

--- a/Core/Parents/EncounterArea.cpp
+++ b/Core/Parents/EncounterArea.cpp
@@ -39,9 +39,11 @@ u8 EncounterArea::getCount() const
 std::pair<u8, u8> EncounterArea::getLevelRange(u16 specie) const
 {
     std::pair<u8, u8> range = std::make_pair(100, 0);
+    u16 num = specie & 0x7ff;
+    u8 form = specie >> 11;
     for (size_t i = 0; i < pokemon.size() && pokemon[i].getSpecie() != 0; i++)
     {
-        if (pokemon[i].getSpecie() == specie)
+        if (pokemon[i].getSpecie() == num && pokemon[i].getForm() == form)
         {
             range.first = std::min(range.first, pokemon[i].getMinLevel());
             range.second = std::max(range.second, pokemon[i].getMaxLevel());

--- a/Core/Parents/Filters/StateFilter.cpp
+++ b/Core/Parents/Filters/StateFilter.cpp
@@ -175,9 +175,10 @@ bool StateFilter::compareState(const State8 &state) const
 
 WildStateFilter::WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                                  const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                                 const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots) :
+                                 const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots, u8 level) :
     StateFilter(gender, ability, shiny, heightMin, heightMax, weightMin, weightMax, skip, ivMin, ivMax, natures, powers),
-    encounterSlots(encounterSlots)
+    encounterSlots(encounterSlots),
+    level(level)
 {
 }
 
@@ -209,6 +210,11 @@ bool WildStateFilter::compareState(const WildGeneratorState &state) const
     }
 
     if (shiny != 255 && !(shiny & state.getShiny()))
+    {
+        return false;
+    }
+
+    if (level != 0 && level != state.getLevel())
     {
         return false;
     }
@@ -247,12 +253,18 @@ bool WildStateFilter::compareState(const WildSearcherState &state) const
         return false;
     }
 
+    if (level != 0 && level != state.getLevel())
+    {
+        return false;
+    }
+
     return true;
 }
 
 bool WildStateFilter::compareState(const WildState &state) const
 {
-    return StateFilter::compareState(static_cast<const State &>(state)) && encounterSlots[state.getEncounterSlot()];
+    return StateFilter::compareState(static_cast<const State &>(state)) && encounterSlots[state.getEncounterSlot()]
+        && (skip || level == 0 || level == state.getLevel());
 }
 
 

--- a/Core/Parents/Filters/StateFilter.cpp
+++ b/Core/Parents/Filters/StateFilter.cpp
@@ -22,9 +22,9 @@
 #include <Core/Gen8/States/State8.hpp>
 #include <Core/Gen8/States/WildState8.hpp>
 
-StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
+StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                          const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                         const std::array<bool, 16> &powers, u8 level) :
+                         const std::array<bool, 16> &powers) :
     skip(skip),
     natures(natures),
     powers(powers),
@@ -34,7 +34,8 @@ StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heigh
     gender(gender),
     heightMax(heightMax),
     heightMin(heightMin),
-    level(level),
+    levelMax(levelMax),
+    levelMin(levelMin),
     shiny(shiny),
     weightMax(weightMax),
     weightMin(weightMin)
@@ -142,7 +143,7 @@ bool StateFilter::compareState(const State &state) const
         return false;
     }
 
-    if (level != 0 && level != state.getLevel())
+    if (state.getLevel() < levelMin || state.getLevel() > levelMax)
     {
         return false;
     }
@@ -179,12 +180,11 @@ bool StateFilter::compareState(const State8 &state) const
     return true;
 }
 
-WildStateFilter::WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
+WildStateFilter::WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                                  const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                                 const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots, u8 level) :
-    StateFilter(gender, ability, shiny, heightMin, heightMax, weightMin, weightMax, skip, ivMin, ivMax, natures, powers),
-    encounterSlots(encounterSlots),
-    level(level)
+                                 const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots) :
+    StateFilter(gender, ability, shiny, levelMin, levelMax, heightMin, heightMax, weightMin, weightMax, skip, ivMin, ivMax, natures, powers),
+    encounterSlots(encounterSlots)
 {
 }
 
@@ -220,7 +220,7 @@ bool WildStateFilter::compareState(const WildGeneratorState &state) const
         return false;
     }
 
-    if (level != 0 && level != state.getLevel())
+    if (state.getLevel() < levelMin || state.getLevel() > levelMax)
     {
         return false;
     }
@@ -259,7 +259,7 @@ bool WildStateFilter::compareState(const WildSearcherState &state) const
         return false;
     }
 
-    if (level != 0 && level != state.getLevel())
+    if (state.getLevel() < levelMin || state.getLevel() > levelMax)
     {
         return false;
     }
@@ -269,8 +269,7 @@ bool WildStateFilter::compareState(const WildSearcherState &state) const
 
 bool WildStateFilter::compareState(const WildState &state) const
 {
-    return StateFilter::compareState(static_cast<const State &>(state)) && encounterSlots[state.getEncounterSlot()]
-        && (skip || level == 0 || level == state.getLevel());
+    return StateFilter::compareState(static_cast<const State &>(state)) && encounterSlots[state.getEncounterSlot()];
 }
 
 

--- a/Core/Parents/Filters/StateFilter.cpp
+++ b/Core/Parents/Filters/StateFilter.cpp
@@ -24,7 +24,7 @@
 
 StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                          const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                         const std::array<bool, 16> &powers) :
+                         const std::array<bool, 16> &powers, u8 level) :
     skip(skip),
     natures(natures),
     powers(powers),
@@ -34,6 +34,7 @@ StateFilter::StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heigh
     gender(gender),
     heightMax(heightMax),
     heightMin(heightMin),
+    level(level),
     shiny(shiny),
     weightMax(weightMax),
     weightMin(weightMin)
@@ -137,6 +138,11 @@ bool StateFilter::compareState(const State &state) const
     }
 
     if (shiny != 255 && !(shiny & state.getShiny()))
+    {
+        return false;
+    }
+
+    if (level != 0 && level != state.getLevel())
     {
         return false;
     }

--- a/Core/Parents/Filters/StateFilter.hpp
+++ b/Core/Parents/Filters/StateFilter.hpp
@@ -55,7 +55,7 @@ public:
      */
     StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                 const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                const std::array<bool, 16> &powers);
+                const std::array<bool, 16> &powers, u8 level = 0);
 
     /**
      * @brief Determines if the \p ability meets the filter criteria
@@ -161,6 +161,7 @@ protected:
     u8 gender;
     u8 heightMax;
     u8 heightMin;
+    u8 level;
     u8 shiny;
     u8 weightMax;
     u8 weightMin;

--- a/Core/Parents/Filters/StateFilter.hpp
+++ b/Core/Parents/Filters/StateFilter.hpp
@@ -190,7 +190,7 @@ public:
      */
     WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                     const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                    const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots);
+                    const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots, u8 level = 0);
 
     /**
      * @brief Determines if the \p encounterSlot meets the filter criteria
@@ -250,6 +250,7 @@ public:
 
 protected:
     std::array<bool, 12> encounterSlots;
+    u8 level;
 };
 
 #endif // STATEFILTER_HPP

--- a/Core/Parents/Filters/StateFilter.hpp
+++ b/Core/Parents/Filters/StateFilter.hpp
@@ -43,6 +43,8 @@ public:
      * @param gender Gender value to filter by
      * @param ability Ability value to filter by
      * @param shiny Shiny value to filter by
+     * @param levelMin Minimum level threshold
+     * @param levelMax Maximum level threshold
      * @param heightMin Minimum height threshold
      * @param heightMax Maximum height threshold
      * @param weightMin Minimum weight threshold
@@ -53,9 +55,9 @@ public:
      * @param natures Natures to filter by
      * @param powers Hidden powers to filter by
      */
-    StateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
+    StateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                 const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                const std::array<bool, 16> &powers, u8 level = 0);
+                const std::array<bool, 16> &powers);
 
     /**
      * @brief Determines if the \p ability meets the filter criteria
@@ -161,7 +163,8 @@ protected:
     u8 gender;
     u8 heightMax;
     u8 heightMin;
-    u8 level;
+    u8 levelMax;
+    u8 levelMin;
     u8 shiny;
     u8 weightMax;
     u8 weightMin;
@@ -179,6 +182,8 @@ public:
      * @param gender Gender value to filter by
      * @param ability Ability value to filter by
      * @param shiny Shiny value to filter by
+     * @param levelMin Minimum level threshold
+     * @param levelMax Maximum level threshold
      * @param heightMin Minimum height threshold
      * @param heightMax Maximum height threshold
      * @param weightMin Minimum weight threshold
@@ -189,9 +194,9 @@ public:
      * @param natures Natures to filter by
      * @param powers Hidden powers to filter by
      */
-    WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
+    WildStateFilter(u8 gender, u8 ability, u8 shiny, u8 levelMin, u8 levelMax, u8 heightMin, u8 heightMax, u8 weightMin, u8 weightMax, bool skip,
                     const std::array<u8, 6> &ivMin, const std::array<u8, 6> &ivMax, const std::array<bool, 25> &natures,
-                    const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots, u8 level = 0);
+                    const std::array<bool, 16> &powers, const std::array<bool, 12> &encounterSlots);
 
     /**
      * @brief Determines if the \p encounterSlot meets the filter criteria
@@ -251,7 +256,6 @@ public:
 
 protected:
     std::array<bool, 12> encounterSlots;
-    u8 level;
 };
 
 #endif // STATEFILTER_HPP

--- a/Form/Controls/ComboBoxProxy.cpp
+++ b/Form/Controls/ComboBoxProxy.cpp
@@ -29,9 +29,11 @@ ComboBoxProxy::ComboBoxProxy(QWidget *parent) : QComboBox(parent)
     setModel(proxyModel);
 }
 
-void ComboBoxProxy::addItem(const QString &string)
+void ComboBoxProxy::addItem(const QString &string, const QVariant &data)
 {
     QStandardItem *item = new QStandardItem(string);
+    item->setData(data);
+
     model->appendRow(item);
 }
 
@@ -40,6 +42,23 @@ void ComboBoxProxy::addItems(const std::vector<std::string> &strings, bool sort)
     for (const auto &string : strings)
     {
         addItem(QString::fromStdString(string));
+    }
+
+    if (sort)
+    {
+        proxyModel->sort(0);
+
+        // Set index back to 0 after sorting
+        QModelIndex index = proxyModel->mapToSource(proxyModel->index(0, 0));
+        setCurrentIndex(index.row());
+    }
+}
+
+void ComboBoxProxy::addItems(const std::vector<std::string> &strings, const std::vector<u16> &data, bool sort)
+{
+    for (int i = 0; i < strings.size() && i < data.size(); i++)
+    {
+        addItem(QString::fromStdString(strings[i]), data[i]);
     }
 
     if (sort)
@@ -65,8 +84,30 @@ void ComboBoxProxy::enableAutoComplete()
     completer()->setCompletionMode(QCompleter::PopupCompletion);
 }
 
+u16 ComboBoxProxy::getCurrentUShort() const
+{
+    QModelIndex index = proxyModel->mapToSource(proxyModel->index(QComboBox::currentIndex(), 0));
+    QStandardItem *item = model->itemFromIndex(index);
+    return item ? item->data().toUInt() : -1;
+}
+
 void ComboBoxProxy::setCurrentIndex(int index)
 {
     QModelIndex modelIndex = proxyModel->mapFromSource(model->index(index, 0));
     QComboBox::setCurrentIndex(modelIndex.row());
+}
+
+void ComboBoxProxy::setCurrentIndexByData(u16 data)
+{
+    for (int i = 0; i < model->rowCount(); i++)
+    {
+        QModelIndex index = model->index(i, 0);
+        QStandardItem *item = model->itemFromIndex(index);
+        if (item->data() == data)
+        {
+            index = proxyModel->mapFromSource(index);
+            QComboBox::setCurrentIndex(index.row());
+            break;
+        }
+    }
 }

--- a/Form/Controls/ComboBoxProxy.hpp
+++ b/Form/Controls/ComboBoxProxy.hpp
@@ -45,8 +45,9 @@ public:
      * @brief Add item to the combobox
      *
      * @param string Item that should be added to the combo box
+     * @param data Data to assign to the item
      */
-    void addItem(const QString &string);
+    void addItem(const QString &string, const QVariant &data = QVariant());
 
     /**
      * @brief Adds items to the combobox
@@ -55,6 +56,15 @@ public:
      * @param sort Whether or not to sort the proxy model
      */
     void addItems(const std::vector<std::string> &strings, bool sort = true);
+
+    /**
+     * @brief Adds items to the combobox
+     *
+     * @param strings List of items that should be added to the combo box
+     * @param data List of data to assign with the items
+     * @param sort Whether or not to sort the proxy model
+     */
+    void addItems(const std::vector<std::string> &strings, const std::vector<u16> &data, bool sort = true);
 
     /**
      * @brief Gets the current index. Maps the index from the proxy model to the model
@@ -67,11 +77,25 @@ public:
     void enableAutoComplete();
 
     /**
+     * @brief Gets current selected index data as u16
+     *
+     * @return Current data
+     */
+    u16 getCurrentUShort() const;
+
+    /**
      * @brief Sets the current index. Maps the index from the model to the proxy model
      *
      * @param index Index to set
      */
     void setCurrentIndex(int index);
+
+    /**
+     * @brief Sets the current index. Maps the index from the model to the proxy model if the data is found
+     *
+     * @param data Data to set index by
+     */
+    void setCurrentIndexByData(u16 data);
 
 private:
     QStandardItemModel *model;

--- a/Form/Controls/Controls.hpp
+++ b/Form/Controls/Controls.hpp
@@ -35,9 +35,10 @@ enum class Controls : u16
     Height = 1 << 4,
     HiddenPowers = 1 << 5,
     IVs = 1 << 6,
-    Natures = 1 << 7,
-    Shiny = 1 << 8,
-    Weight = 1 << 9
+    Level = 1 << 7,
+    Natures = 1 << 8,
+    Shiny = 1 << 9,
+    Weight = 1 << 10
 };
 
 /**

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -76,6 +76,8 @@ Filter::Filter(QWidget *parent) : QWidget(parent), ui(new Ui::Filter)
     ui->checkListHiddenPower->addItems(Translator::getHiddenPowers());
     ui->checkListNature->addItems(Translator::getNatures());
     ui->comboBoxShiny->setup({ 255, 1, 2, 3 });
+    ui->pushButtonLevelReset->setText(tr("Reset"));
+    setLevelVisible(false);
 
     ui->checkListEncounterSlot->setToolTip(tr("Click holding ctrl to reset"));
     ui->checkListHiddenPower->setToolTip(tr("Click holding ctrl to reset"));
@@ -120,6 +122,7 @@ Filter::Filter(QWidget *parent) : QWidget(parent), ui(new Ui::Filter)
     connect(ui->spinBoxSpeMax, &QSpinBox::valueChanged, this, &Filter::ivsChanged);
     connect(ui->checkBoxShowStats, &QCheckBox::checkStateChanged, this,
             [=](Qt::CheckState state) { emit showStatsChanged(state == Qt::Checked); });
+    connect(ui->pushButtonLevelReset, &QPushButton::clicked, this, [=] { ui->spinBoxLevel->setValue(0); });
     connect(ui->pushButtonIVCalculator, &QPushButton::clicked, this, &Filter::openIVCalculator);
 }
 
@@ -154,6 +157,7 @@ void Filter::copyFrom(const Filter *other)
     ui->comboBoxAbility->setCurrentIndex(other->ui->comboBoxAbility->currentIndex());
     ui->checkListEncounterSlot->setChecks(other->ui->checkListEncounterSlot->getChecked());
     ui->comboBoxGender->setCurrentIndex(other->ui->comboBoxGender->currentIndex());
+    ui->spinBoxLevel->setValue(other->ui->spinBoxLevel->value());
     ui->spinBoxHeightMin->setValue(other->ui->spinBoxHeightMin->value());
     ui->spinBoxHeightMax->setValue(other->ui->spinBoxHeightMax->value());
     ui->checkListHiddenPower->setChecks(other->ui->checkListHiddenPower->getChecked());
@@ -289,6 +293,11 @@ u8 Filter::getHeightMin() const
     return static_cast<u8>(ui->spinBoxHeightMin->value());
 }
 
+u8 Filter::getLevel() const
+{
+    return static_cast<u8>(ui->spinBoxLevel->value());
+}
+
 std::array<bool, 16> Filter::getHiddenPowers() const
 {
     return ui->checkListHiddenPower->getCheckedArray<16>();
@@ -384,6 +393,17 @@ bool Filter::isValid() const
     }
 
     return true;
+}
+
+void Filter::setLevelVisible(bool flag) const
+{
+    ui->labelLevel->setVisible(flag);
+    ui->spinBoxLevel->setVisible(flag);
+    ui->pushButtonLevelReset->setVisible(flag);
+    if (!flag)
+    {
+        ui->spinBoxLevel->setValue(0);
+    }
 }
 
 void Filter::resetEncounterSlots() const

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -76,8 +76,6 @@ Filter::Filter(QWidget *parent) : QWidget(parent), ui(new Ui::Filter)
     ui->checkListHiddenPower->addItems(Translator::getHiddenPowers());
     ui->checkListNature->addItems(Translator::getNatures());
     ui->comboBoxShiny->setup({ 255, 1, 2, 3 });
-    ui->pushButtonLevelReset->setText(tr("Reset"));
-    setLevelVisible(false);
 
     ui->checkListEncounterSlot->setToolTip(tr("Click holding ctrl to reset"));
     ui->checkListHiddenPower->setToolTip(tr("Click holding ctrl to reset"));
@@ -122,7 +120,6 @@ Filter::Filter(QWidget *parent) : QWidget(parent), ui(new Ui::Filter)
     connect(ui->spinBoxSpeMax, &QSpinBox::valueChanged, this, &Filter::ivsChanged);
     connect(ui->checkBoxShowStats, &QCheckBox::checkStateChanged, this,
             [=](Qt::CheckState state) { emit showStatsChanged(state == Qt::Checked); });
-    connect(ui->pushButtonLevelReset, &QPushButton::clicked, this, [=] { ui->spinBoxLevel->setValue(0); });
     connect(ui->pushButtonIVCalculator, &QPushButton::clicked, this, &Filter::openIVCalculator);
 }
 
@@ -157,10 +154,11 @@ void Filter::copyFrom(const Filter *other)
     ui->comboBoxAbility->setCurrentIndex(other->ui->comboBoxAbility->currentIndex());
     ui->checkListEncounterSlot->setChecks(other->ui->checkListEncounterSlot->getChecked());
     ui->comboBoxGender->setCurrentIndex(other->ui->comboBoxGender->currentIndex());
-    ui->spinBoxLevel->setValue(other->ui->spinBoxLevel->value());
     ui->spinBoxHeightMin->setValue(other->ui->spinBoxHeightMin->value());
     ui->spinBoxHeightMax->setValue(other->ui->spinBoxHeightMax->value());
     ui->checkListHiddenPower->setChecks(other->ui->checkListHiddenPower->getChecked());
+    ui->spinBoxLevelMax->setValue(other->ui->spinBoxLevelMax->value());
+    ui->spinBoxLevelMin->setValue(other->ui->spinBoxLevelMin->value());
     ui->checkListNature->setChecks(other->ui->checkListNature->getChecked());
     ui->comboBoxShiny->setCurrentIndex(other->ui->comboBoxShiny->currentIndex());
     ui->spinBoxWeightMin->setValue(other->ui->spinBoxWeightMin->value());
@@ -236,6 +234,13 @@ void Filter::disableControls(Controls control)
         ui->pushButtonIVCalculator->setVisible(false);
     }
 
+    if ((control & Controls::Level) != Controls::None)
+    {
+        ui->labelLevel->setVisible(false);
+        ui->spinBoxLevelMin->setVisible(false);
+        ui->spinBoxLevelMax->setVisible(false);
+    }
+
     if ((control & Controls::Natures) != Controls::None)
     {
         ui->labelNature->setVisible(false);
@@ -293,14 +298,19 @@ u8 Filter::getHeightMin() const
     return static_cast<u8>(ui->spinBoxHeightMin->value());
 }
 
-u8 Filter::getLevel() const
-{
-    return static_cast<u8>(ui->spinBoxLevel->value());
-}
-
 std::array<bool, 16> Filter::getHiddenPowers() const
 {
     return ui->checkListHiddenPower->getCheckedArray<16>();
+}
+
+u8 Filter::getLevelMax() const
+{
+    return static_cast<u8>(ui->spinBoxLevelMax->value());
+}
+
+u8 Filter::getLevelMin() const
+{
+    return static_cast<u8>(ui->spinBoxLevelMin->value());
 }
 
 std::array<u8, 6> Filter::getMaxIVs() const
@@ -334,13 +344,6 @@ bool Filter::isValid() const
     if (ui->checkBoxDisableFilters->isChecked())
     {
         return true;
-    }
-
-    if (ui->spinBoxHeightMin->value() > ui->spinBoxHeightMax->value())
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid filter settings"), tr("Height minimum is greater than maximum"));
-        msg.exec();
-        return false;
     }
 
     if (ui->spinBoxHPMin->value() > ui->spinBoxHPMax->value())
@@ -385,6 +388,20 @@ bool Filter::isValid() const
         return false;
     }
 
+    if (ui->spinBoxLevelMin->value() > ui->spinBoxLevelMax->value())
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid filter settings"), tr("Level minimum is greater than maximum"));
+        msg.exec();
+        return false;
+    }
+
+    if (ui->spinBoxHeightMin->value() > ui->spinBoxHeightMax->value())
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid filter settings"), tr("Height minimum is greater than maximum"));
+        msg.exec();
+        return false;
+    }
+
     if (ui->spinBoxWeightMin->value() > ui->spinBoxWeightMax->value())
     {
         QMessageBox msg(QMessageBox::Warning, tr("Invalid filter settings"), tr("Weight minimum is greater than maximum"));
@@ -393,17 +410,6 @@ bool Filter::isValid() const
     }
 
     return true;
-}
-
-void Filter::setLevelVisible(bool flag) const
-{
-    ui->labelLevel->setVisible(flag);
-    ui->spinBoxLevel->setVisible(flag);
-    ui->pushButtonLevelReset->setVisible(flag);
-    if (!flag)
-    {
-        ui->spinBoxLevel->setValue(0);
-    }
 }
 
 void Filter::resetEncounterSlots() const

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -157,8 +157,8 @@ void Filter::copyFrom(const Filter *other)
     ui->spinBoxHeightMin->setValue(other->ui->spinBoxHeightMin->value());
     ui->spinBoxHeightMax->setValue(other->ui->spinBoxHeightMax->value());
     ui->checkListHiddenPower->setChecks(other->ui->checkListHiddenPower->getChecked());
-    ui->spinBoxLevelMax->setValue(other->ui->spinBoxLevelMax->value());
     ui->spinBoxLevelMin->setValue(other->ui->spinBoxLevelMin->value());
+    ui->spinBoxLevelMax->setValue(other->ui->spinBoxLevelMax->value());
     ui->checkListNature->setChecks(other->ui->checkListNature->getChecked());
     ui->comboBoxShiny->setCurrentIndex(other->ui->comboBoxShiny->currentIndex());
     ui->spinBoxWeightMin->setValue(other->ui->spinBoxWeightMin->value());

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -414,6 +414,11 @@ bool Filter::isValid() const
 
 bool Filter::isValid(u32 min, u32 max) const
 {
+    if (ui->checkBoxDisableFilters->isChecked())
+    {
+        return true;
+    }
+
     if (!isValid())
     {
         return false;

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -412,7 +412,7 @@ bool Filter::isValid() const
     return true;
 }
 
-bool Filter::isValid(u32 min, u32 max)
+bool Filter::isValid(u32 min, u32 max) const
 {
     if (!isValid())
     {

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -424,7 +424,7 @@ bool Filter::isValid(u32 min, u32 max) const
         return false;
     }
 
-    if ((min != 0 || max != 0) && (getLevelMin() < min || getLevelMax() > max))
+    if ((min != 0 || max != 0) && (getLevelMax() < min || getLevelMin() > max))
     {
         QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range"));
         msg.exec();

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -412,6 +412,23 @@ bool Filter::isValid() const
     return true;
 }
 
+bool Filter::isValid(u32 min, u32 max)
+{
+    if (!isValid())
+    {
+        return false;
+    }
+
+    if ((min != 0 || max != 0) && (getLevelMin() < min || getLevelMax() > max))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range"));
+        msg.exec();
+        return false;
+    }
+
+    return true;
+}
+
 void Filter::resetEncounterSlots() const
 {
     ui->checkListEncounterSlot->resetChecks();
@@ -425,6 +442,12 @@ void Filter::setEncounterSlots(u8 max) const
         items.emplace_back(std::to_string(i));
     }
     ui->checkListEncounterSlot->addItems(items);
+}
+
+void Filter::setLevelRange(u32 min, u32 max)
+{
+    ui->spinBoxLevelMin->setValue(min);
+    ui->spinBoxLevelMax->setValue(max);
 }
 
 void Filter::toggleEncounterSlots(const std::vector<bool> &encounterSlots) const

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -122,14 +122,15 @@ public:
     {
         if constexpr (wild)
         {
-            return FilterType(getGender(), getAbility(), getShiny(), getHeightMin(), getHeightMax(), getWeightMin(), getWeightMax(),
-                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers(), getEncounterSlots(),
-                              getLevel());
+            return FilterType(getGender(), getAbility(), getShiny(), getLevelMin(), getLevelMax(), getHeightMin(), getHeightMax(),
+                              getWeightMin(), getWeightMax(), getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(),
+                              getHiddenPowers(), getEncounterSlots());
         }
         else
         {
-            return FilterType(getGender(), getAbility(), getShiny(), getHeightMin(), getHeightMax(), getWeightMin(), getWeightMax(),
-                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers(), getLevel());
+            return FilterType(getGender(), getAbility(), getShiny(), getLevelMin(), getLevelMax(), getHeightMin(), getHeightMax(),
+                              getWeightMin(), getWeightMax(), getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(),
+                              getHiddenPowers());
         }
     }
 
@@ -155,18 +156,25 @@ public:
     u8 getHeightMin() const;
 
     /**
-     * @brief Gets level to filter by
-     *
-     * @return Level value
-     */
-    u8 getLevel() const;
-
-    /**
      * @brief Gets hidden powers to filter by
      *
      * @return Array of hidden powers
      */
     std::array<bool, 16> getHiddenPowers() const;
+
+    /**
+     * @brief Gets max level to filter by
+     *
+     * @return Level value
+     */
+    u8 getLevelMax() const;
+
+    /**
+     * @brief Gets min level to filter by
+     *
+     * @return Level value
+     */
+    u8 getLevelMin() const;
 
     /**
      * @brief Gets upper bound IVs to filter by
@@ -200,13 +208,6 @@ public:
      * @brief Determines if Filter is valid based on current selections
      */
     bool isValid() const;
-
-    /**
-     * @brief Shows or hides the level filter
-     *
-     * @param flag Whether to show the level filter
-     */
-    void setLevelVisible(bool flag) const;
 
     /**
      * @brief Unchecks all encounter slots

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -129,7 +129,7 @@ public:
         else
         {
             return FilterType(getGender(), getAbility(), getShiny(), getHeightMin(), getHeightMax(), getWeightMin(), getWeightMax(),
-                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers());
+                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers(), getLevel());
         }
     }
 

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -221,7 +221,7 @@ public:
      * @return true Filter is valid
      * @return false Filter is not valid
      */
-    bool isValid(u32 min, u32 max);
+    bool isValid(u32 min, u32 max) const;
 
     /**
      * @brief Unchecks all encounter slots

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -206,8 +206,22 @@ public:
 
     /**
      * @brief Determines if Filter is valid based on current selections
+     *
+     * @return true Filter is valid
+     * @return false Filter is not valid
      */
     bool isValid() const;
+
+    /**
+     * @brief Determines if Filter is valid based on current selections. Additionally checks against input level range
+     * 
+     * @param min Minimum level
+     * @param max Maximum level
+     *
+     * @return true Filter is valid
+     * @return false Filter is not valid
+     */
+    bool isValid(u32 min, u32 max);
 
     /**
      * @brief Unchecks all encounter slots
@@ -220,6 +234,14 @@ public:
      * @param max Number of encounter slots
      */
     void setEncounterSlots(u8 max) const;
+
+    /**
+     * @brief Sets level range
+     *
+     * @param min Minimum level
+     * @param max Maximum level
+     */
+    void setLevelRange(u32 min, u32 max);
 
     /**
      * @brief Sets encounter slots that are checked and not checked

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -123,7 +123,8 @@ public:
         if constexpr (wild)
         {
             return FilterType(getGender(), getAbility(), getShiny(), getHeightMin(), getHeightMax(), getWeightMin(), getWeightMax(),
-                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers(), getEncounterSlots());
+                              getDisableFilters(), getMinIVs(), getMaxIVs(), getNatures(), getHiddenPowers(), getEncounterSlots(),
+                              getLevel());
         }
         else
         {
@@ -152,6 +153,13 @@ public:
      * @return Minimum height
      */
     u8 getHeightMin() const;
+
+    /**
+     * @brief Gets level to filter by
+     *
+     * @return Level value
+     */
+    u8 getLevel() const;
 
     /**
      * @brief Gets hidden powers to filter by
@@ -192,6 +200,13 @@ public:
      * @brief Determines if Filter is valid based on current selections
      */
     bool isValid() const;
+
+    /**
+     * @brief Shows or hides the level filter
+     *
+     * @param flag Whether to show the level filter
+     */
+    void setLevelVisible(bool flag) const;
 
     /**
      * @brief Unchecks all encounter slots

--- a/Form/Controls/Filter.ui
+++ b/Form/Controls/Filter.ui
@@ -320,20 +320,41 @@
       </widget>
      </item>
      <item row="7" column="0">
+      <widget class="QLabel" name="labelLevel">
+       <property name="text">
+        <string>Level</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QSpinBox" name="spinBoxLevel">
+       <property name="maximum">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="QPushButton" name="pushButtonLevelReset">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
       <widget class="QLabel" name="labelWeight">
        <property name="text">
         <string>Weight</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QSpinBox" name="spinBoxWeightMin">
        <property name="maximum">
         <number>255</number>
        </property>
       </widget>
      </item>
-     <item row="7" column="2">
+     <item row="8" column="2">
       <widget class="QSpinBox" name="spinBoxWeightMax">
        <property name="maximum">
         <number>255</number>
@@ -343,7 +364,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0" colspan="3">
+     <item row="9" column="0" colspan="3">
       <widget class="QCheckBox" name="checkBoxDisableFilters">
        <property name="text">
         <string>Disable Filters</string>

--- a/Form/Controls/Filter.ui
+++ b/Form/Controls/Filter.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>306</width>
-    <height>238</height>
+    <height>292</height>
    </rect>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
@@ -279,23 +279,53 @@
       <widget class="CheckList" name="checkListHiddenPower"/>
      </item>
      <item row="5" column="0">
+      <widget class="QLabel" name="labelLevel">
+       <property name="text">
+        <string>Level</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="spinBoxLevelMin">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QSpinBox" name="spinBoxLevelMax">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
       <widget class="QLabel" name="labelNature">
        <property name="text">
         <string>Nature</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="2">
+     <item row="6" column="1" colspan="2">
       <widget class="CheckList" name="checkListNature"/>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="labelShiny">
        <property name="text">
         <string>Shiny</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1" colspan="2">
+     <item row="7" column="1" colspan="2">
       <widget class="ComboBox" name="comboBoxShiny">
        <item>
         <property name="text">
@@ -317,27 +347,6 @@
          <string>Star/Square</string>
         </property>
        </item>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelLevel">
-       <property name="text">
-        <string>Level</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QSpinBox" name="spinBoxLevel">
-       <property name="maximum">
-        <number>100</number>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="2">
-      <widget class="QPushButton" name="pushButtonLevelReset">
-       <property name="text">
-        <string>Reset</string>
-       </property>
       </widget>
      </item>
      <item row="8" column="0">
@@ -408,6 +417,8 @@
   <tabstop>spinBoxHeightMin</tabstop>
   <tabstop>spinBoxHeightMax</tabstop>
   <tabstop>checkListHiddenPower</tabstop>
+  <tabstop>spinBoxLevelMin</tabstop>
+  <tabstop>spinBoxLevelMax</tabstop>
   <tabstop>checkListNature</tabstop>
   <tabstop>comboBoxShiny</tabstop>
   <tabstop>spinBoxWeightMin</tabstop>

--- a/Form/Gen3/Eggs3.cpp
+++ b/Form/Gen3/Eggs3.cpp
@@ -68,8 +68,10 @@ Eggs3::Eggs3(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs3)
     ui->comboBoxRSFRLGMethod->setup(
         { toInt(Method::RSFRLGBred), toInt(Method::RSFRLGBredSplit), toInt(Method::RSFRLGBredAlternate), toInt(Method::RSFRLGBredMixed) });
 
-    ui->filterEmerald->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterRSFRLG->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterEmerald->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                       | Controls::Weight);
+    ui->filterRSFRLG->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                      | Controls::Weight);
 
     ui->eggSettingsEmerald->setup(Game::Emerald);
     ui->eggSettingsRSFRLG->setup(Game::RS | Game::FRLG);

--- a/Form/Gen3/GameCube.cpp
+++ b/Form/Gen3/GameCube.cpp
@@ -55,8 +55,9 @@ GameCube::GameCube(QWidget *parent) : QWidget(parent), ui(new Ui::GameCube)
     ui->textBoxGeneratorMaxAdvances->setValues(InputType::Advance32Bit);
     ui->textBoxGeneratorOffset->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->comboBoxGeneratorPokemon->enableAutoComplete();
     ui->comboBoxSearcherPokemon->enableAutoComplete();

--- a/Form/Gen3/Static3.cpp
+++ b/Form/Gen3/Static3.cpp
@@ -58,8 +58,9 @@ Static3::Static3(QWidget *parent) : QWidget(parent), ui(new Ui::Static3)
     ui->comboBoxGeneratorMethod->setup({ toInt(Method::Method1), toInt(Method::Method4) });
     ui->comboBoxSearcherMethod->setup({ toInt(Method::Method1), toInt(Method::Method4) });
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     auto *seedToTime = new QAction(tr("Generate times for seed"), ui->tableViewSearcher);
     connect(seedToTime, &QAction::triggered, this, &Static3::seedToTime);

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -36,9 +36,21 @@
 #include <Model/Gen3/WildModel3.hpp>
 #include <Model/SortFilterProxyModel.hpp>
 #include <QAction>
+#include <QMessageBox>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+
+static bool hasLevelRange(Encounter encounter)
+{
+    return encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
+        || encounter == Encounter::SuperRod;
+}
+
+static std::pair<u8, u8> getLevelRange(const EncounterArea3 &area, u16 specie)
+{
+    return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
+}
 
 Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 {
@@ -67,6 +79,8 @@ Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
+    ui->filterGenerator->setLevelVisible(false);
+    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"),
@@ -177,10 +191,58 @@ void Wild3::updateEncounterSearcher()
     encounterSearcher = Encounters3::getEncounters(encounter, settings, currentProfile->getVersion());
 }
 
+void Wild3::updateGeneratorLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
+    ui->labelGeneratorLevelRange->setVisible(visible);
+    ui->widgetGeneratorLevelRange->setVisible(visible);
+    ui->filterGenerator->setLevelVisible(visible);
+
+    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
+    {
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
+    ui->spinBoxGeneratorLevelMin->setValue(range.first);
+    ui->spinBoxGeneratorLevelMax->setValue(range.second);
+}
+
+void Wild3::updateSearcherLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
+    ui->labelSearcherLevelRange->setVisible(visible);
+    ui->widgetSearcherLevelRange->setVisible(visible);
+    ui->filterSearcher->setLevelVisible(visible);
+
+    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
+    {
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
+    ui->spinBoxSearcherLevelMin->setValue(range.first);
+    ui->spinBoxSearcherLevelMax->setValue(range.second);
+}
+
 void Wild3::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterGenerator->getLevel();
+    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -220,6 +282,7 @@ void Wild3::generatorEncounterIndexChanged(int index)
 
         ui->comboBoxGeneratorLocation->clear();
         ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        updateGeneratorLevelRange();
     }
 }
 
@@ -257,6 +320,7 @@ void Wild3::generatorLocationIndexChanged(int index)
         {
             ui->comboBoxGeneratorPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
+        updateGeneratorLevelRange();
     }
 }
 
@@ -272,6 +336,7 @@ void Wild3::generatorPokemonIndexChanged(int index)
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
     }
+    updateGeneratorLevelRange();
 }
 
 void Wild3::profileIndexChanged(int index)
@@ -324,6 +389,14 @@ void Wild3::search()
 {
     if (!ui->filterSearcher->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterSearcher->getLevel();
+    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -390,6 +463,7 @@ void Wild3::searcherEncounterIndexChanged(int index)
 
         ui->comboBoxSearcherLocation->clear();
         ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        updateSearcherLevelRange();
     }
 }
 
@@ -427,6 +501,7 @@ void Wild3::searcherLocationIndexChanged(int index)
         {
             ui->comboBoxSearcherPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
+        updateSearcherLevelRange();
     }
 }
 
@@ -442,6 +517,7 @@ void Wild3::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
     }
+    updateSearcherLevelRange();
 }
 
 void Wild3::seedToTime()

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -387,7 +387,7 @@ void Wild3::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
-        u16 currentLocation = ui->comboBoxGeneratorLocation->getCurrentUShort();
+        u16 currentLocation = ui->comboBoxSearcherLocation->getCurrentUShort();
 
         bool magnetPullOption = encounter == Encounter::Grass;
         bool staticOption = encounter == Encounter::Grass || encounter == Encounter::Surfing;
@@ -457,7 +457,7 @@ void Wild3::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
 
-        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        auto range = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
         ui->filterSearcher->setLevelRange(range.first, range.second);

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -52,6 +52,12 @@ static std::pair<u8, u8> getLevelRange(const EncounterArea3 &area, u16 specie)
     return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
 }
 
+static int findLocationName(const std::vector<std::string> &locations, const QString &location)
+{
+    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
+    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
+}
+
 Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 {
     ui->setupUi(this);
@@ -269,6 +275,8 @@ void Wild3::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
 
         bool magnetPullOption = encounter == Encounter::Grass;
         bool staticOption = encounter == Encounter::Grass || encounter == Encounter::Surfing;
@@ -281,7 +289,13 @@ void Wild3::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea3 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxGeneratorLocation->addItems(locations);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
+        }
         updateGeneratorLevelRange();
     }
 }
@@ -450,6 +464,8 @@ void Wild3::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
 
         bool magnetPullOption = encounter == Encounter::Grass;
         bool staticOption = encounter == Encounter::Grass || encounter == Encounter::Surfing;
@@ -462,7 +478,13 @@ void Wild3::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea3 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxSearcherLocation->addItems(locations);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
+        }
         updateSearcherLevelRange();
     }
 }

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -43,8 +43,8 @@
 
 static bool hasLevelRange(Encounter encounter)
 {
-    return encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
-        || encounter == Encounter::SuperRod;
+    return encounter == Encounter::RockSmash || encounter == Encounter::Surfing || encounter == Encounter::OldRod
+        || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
 }
 
 static std::pair<u8, u8> getLevelRange(const EncounterArea3 &area, u16 specie)

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -31,7 +31,6 @@
 #include <Core/Util/Nature.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
-#include <Form/Controls/Filter.hpp>
 #include <Form/Gen3/Profile/ProfileManager3.hpp>
 #include <Form/Gen3/Tools/SeedToTime3.hpp>
 #include <Model/Gen3/WildModel3.hpp>
@@ -41,11 +40,6 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-
-static bool validLevelRange(const Filter *filter, int min, int max)
-{
-    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
-}
 
 Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 {
@@ -186,15 +180,8 @@ void Wild3::updateEncounterSearcher()
 
 void Wild3::generate()
 {
-    if (!ui->filterGenerator->isValid())
+    if (!ui->filterGenerator->isValid(ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -283,6 +270,7 @@ void Wild3::generatorPokemonIndexChanged(int index)
         ui->filterGenerator->resetEncounterSlots();
         ui->spinBoxGeneratorLevelMin->setValue(0);
         ui->spinBoxGeneratorLevelMax->setValue(0);
+        ui->filterGenerator->setLevelRange(1, 100);
     }
     else
     {
@@ -293,6 +281,7 @@ void Wild3::generatorPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxGeneratorLevelMin->setValue(range.first);
         ui->spinBoxGeneratorLevelMax->setValue(range.second);
+        ui->filterGenerator->setLevelRange(range.first, range.second);
     }
 }
 
@@ -344,15 +333,8 @@ void Wild3::profileManager()
 
 void Wild3::search()
 {
-    if (!ui->filterSearcher->isValid())
+    if (!ui->filterSearcher->isValid(ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -468,6 +450,7 @@ void Wild3::searcherPokemonIndexChanged(int index)
         ui->filterSearcher->resetEncounterSlots();
         ui->spinBoxSearcherLevelMin->setValue(0);
         ui->spinBoxSearcherLevelMax->setValue(0);
+        ui->filterSearcher->setLevelRange(1, 100);
     }
     else
     {
@@ -478,6 +461,7 @@ void Wild3::searcherPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
+        ui->filterSearcher->setLevelRange(range.first, range.second);
     }
 }
 

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -31,14 +31,21 @@
 #include <Core/Util/Nature.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
+#include <Form/Controls/Filter.hpp>
 #include <Form/Gen3/Profile/ProfileManager3.hpp>
 #include <Form/Gen3/Tools/SeedToTime3.hpp>
 #include <Model/Gen3/WildModel3.hpp>
 #include <Model/SortFilterProxyModel.hpp>
 #include <QAction>
+#include <QMessageBox>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+
+static bool validLevelRange(const Filter *filter, int min, int max)
+{
+    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
+}
 
 Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 {
@@ -181,6 +188,13 @@ void Wild3::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -332,6 +346,13 @@ void Wild3::search()
 {
     if (!ui->filterSearcher->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -259,8 +259,6 @@ void Wild3::generatorLocationIndexChanged(int index)
         {
             ui->comboBoxGeneratorPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
-
-        generatorPokemonIndexChanged(0);
     }
 }
 

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -36,7 +36,6 @@
 #include <Model/Gen3/WildModel3.hpp>
 #include <Model/SortFilterProxyModel.hpp>
 #include <QAction>
-#include <QMessageBox>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>

--- a/Form/Gen3/Wild3.cpp
+++ b/Form/Gen3/Wild3.cpp
@@ -36,27 +36,9 @@
 #include <Model/Gen3/WildModel3.hpp>
 #include <Model/SortFilterProxyModel.hpp>
 #include <QAction>
-#include <QMessageBox>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-
-static bool hasLevelRange(Encounter encounter)
-{
-    return encounter == Encounter::RockSmash || encounter == Encounter::Surfing || encounter == Encounter::OldRod
-        || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
-}
-
-static std::pair<u8, u8> getLevelRange(const EncounterArea3 &area, u16 specie)
-{
-    return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
-}
-
-static int findLocationName(const std::vector<std::string> &locations, const QString &location)
-{
-    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
-    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
-}
 
 Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 {
@@ -85,8 +67,6 @@ Wild3::Wild3(QWidget *parent) : QWidget(parent), ui(new Ui::Wild3)
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
-    ui->filterGenerator->setLevelVisible(false);
-    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"),
@@ -197,58 +177,10 @@ void Wild3::updateEncounterSearcher()
     encounterSearcher = Encounters3::getEncounters(encounter, settings, currentProfile->getVersion());
 }
 
-void Wild3::updateGeneratorLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
-    ui->labelGeneratorLevelRange->setVisible(visible);
-    ui->widgetGeneratorLevelRange->setVisible(visible);
-    ui->filterGenerator->setLevelVisible(visible);
-
-    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
-    {
-        ui->spinBoxGeneratorLevelMin->setValue(0);
-        ui->spinBoxGeneratorLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
-    ui->spinBoxGeneratorLevelMin->setValue(range.first);
-    ui->spinBoxGeneratorLevelMax->setValue(range.second);
-}
-
-void Wild3::updateSearcherLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
-    ui->labelSearcherLevelRange->setVisible(visible);
-    ui->widgetSearcherLevelRange->setVisible(visible);
-    ui->filterSearcher->setLevelVisible(visible);
-
-    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
-    {
-        ui->spinBoxSearcherLevelMin->setValue(0);
-        ui->spinBoxSearcherLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
-    ui->spinBoxSearcherLevelMin->setValue(range.first);
-    ui->spinBoxSearcherLevelMax->setValue(range.second);
-}
-
 void Wild3::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
-        return;
-    }
-
-    u8 level = ui->filterGenerator->getLevel();
-    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -275,8 +207,7 @@ void Wild3::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxGeneratorLocation->getCurrentUShort();
 
         bool magnetPullOption = encounter == Encounter::Grass;
         bool staticOption = encounter == Encounter::Grass || encounter == Encounter::Surfing;
@@ -289,14 +220,8 @@ void Wild3::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea3 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxGeneratorLocation->addItems(locations);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
-        }
-        updateGeneratorLevelRange();
+        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxGeneratorLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -334,7 +259,8 @@ void Wild3::generatorLocationIndexChanged(int index)
         {
             ui->comboBoxGeneratorPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
-        updateGeneratorLevelRange();
+
+        generatorPokemonIndexChanged(0);
     }
 }
 
@@ -343,14 +269,19 @@ void Wild3::generatorPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterGenerator->resetEncounterSlots();
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxGeneratorPokemon->getCurrentUShort();
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxGeneratorLevelMin->setValue(range.first);
+        ui->spinBoxGeneratorLevelMax->setValue(range.second);
     }
-    updateGeneratorLevelRange();
 }
 
 void Wild3::profileIndexChanged(int index)
@@ -406,14 +337,6 @@ void Wild3::search()
         return;
     }
 
-    u8 level = ui->filterSearcher->getLevel();
-    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
-        return;
-    }
-
     searcherModel->clearModel();
 
     ui->pushButtonSearch->setEnabled(false);
@@ -464,8 +387,7 @@ void Wild3::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxGeneratorLocation->getCurrentUShort();
 
         bool magnetPullOption = encounter == Encounter::Grass;
         bool staticOption = encounter == Encounter::Grass || encounter == Encounter::Surfing;
@@ -478,14 +400,8 @@ void Wild3::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea3 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxSearcherLocation->addItems(locations);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
-        }
-        updateSearcherLevelRange();
+        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxSearcherLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -523,7 +439,6 @@ void Wild3::searcherLocationIndexChanged(int index)
         {
             ui->comboBoxSearcherPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
-        updateSearcherLevelRange();
     }
 }
 
@@ -532,14 +447,19 @@ void Wild3::searcherPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterSearcher->resetEncounterSlots();
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxSearcherPokemon->getCurrentUShort();
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxSearcherLevelMin->setValue(range.first);
+        ui->spinBoxSearcherLevelMax->setValue(range.second);
     }
-    updateSearcherLevelRange();
 }
 
 void Wild3::seedToTime()

--- a/Form/Gen3/Wild3.hpp
+++ b/Form/Gen3/Wild3.hpp
@@ -85,16 +85,6 @@ private:
      */
     void updateEncounterSearcher();
 
-    /**
-     * @brief Updates the displayed level range for the generator tab
-     */
-    void updateGeneratorLevelRange() const;
-
-    /**
-     * @brief Updates the displayed level range for the searcher tab
-     */
-    void updateSearcherLevelRange() const;
-
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen3/Wild3.hpp
+++ b/Form/Gen3/Wild3.hpp
@@ -85,6 +85,16 @@ private:
      */
     void updateEncounterSearcher();
 
+    /**
+     * @brief Updates the displayed level range for the generator tab
+     */
+    void updateGeneratorLevelRange() const;
+
+    /**
+     * @brief Updates the displayed level range for the searcher tab
+     */
+    void updateSearcherLevelRange() const;
+
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen3/Wild3.ui
+++ b/Form/Gen3/Wild3.ui
@@ -255,7 +255,78 @@
           <item row="2" column="1">
            <widget class="ComboBox" name="comboBoxGeneratorPokemon"/>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelGeneratorLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelGeneratorLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelGeneratorLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBoxGeneratorFeebasTile">
             <property name="text">
              <string>Feebas Tile</string>
@@ -426,7 +497,78 @@
           <item row="2" column="1">
            <widget class="ComboBox" name="comboBoxSearcherPokemon"/>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSearcherLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelSearcherLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelSearcherLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBoxSearcherFeebasTile">
             <property name="text">
              <string>Feebas Tile</string>

--- a/Form/Gen3/Wild3.ui
+++ b/Form/Gen3/Wild3.ui
@@ -201,7 +201,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxGeneratorEncounter">
             <item>
              <property name="text">
@@ -242,7 +242,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="1" column="1" colspan="2">
            <widget class="ComboBoxProxy" name="comboBoxGeneratorLocation"/>
           </item>
           <item row="2" column="0">
@@ -252,84 +252,41 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="2" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxGeneratorPokemon"/>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="labelGeneratorLevelRange">
-            <property name="text">
-             <string>Level Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelGeneratorLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelGeneratorLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
+          <item row="3" column="0" colspan="3">
            <widget class="QCheckBox" name="checkBoxGeneratorFeebasTile">
             <property name="text">
              <string>Feebas Tile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelGeneratorLevel">
+            <property name="text">
+             <string>Levels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -443,7 +400,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxSearcherEncounter">
             <item>
              <property name="text">
@@ -484,7 +441,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="1" column="1" colspan="2">
            <widget class="ComboBoxProxy" name="comboBoxSearcherLocation"/>
           </item>
           <item row="2" column="0">
@@ -494,84 +451,41 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="2" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxSearcherPokemon"/>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="labelSearcherLevelRange">
-            <property name="text">
-             <string>Level Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelSearcherLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelSearcherLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
+          <item row="3" column="0" colspan="3">
            <widget class="QCheckBox" name="checkBoxSearcherFeebasTile">
             <property name="text">
              <string>Feebas Tile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="Line" name="line_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelSearcherLevel">
+            <property name="text">
+             <string>Levels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -646,11 +560,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ComboBox</class>
-   <extends>QComboBox</extends>
-   <header>Form/Controls/ComboBox.hpp</header>
-  </customwidget>
-  <customwidget>
    <class>ComboMenu</class>
    <extends>QToolButton</extends>
    <header>Form/Controls/ComboMenu.hpp</header>
@@ -671,6 +580,8 @@
   <tabstop>comboBoxGeneratorLocation</tabstop>
   <tabstop>comboBoxGeneratorPokemon</tabstop>
   <tabstop>checkBoxGeneratorFeebasTile</tabstop>
+  <tabstop>spinBoxGeneratorLevelMin</tabstop>
+  <tabstop>spinBoxGeneratorLevelMax</tabstop>
   <tabstop>tableViewGenerator</tabstop>
   <tabstop>comboBoxSearcherMethod</tabstop>
   <tabstop>comboMenuSearcherLead</tabstop>
@@ -680,6 +591,8 @@
   <tabstop>comboBoxSearcherLocation</tabstop>
   <tabstop>comboBoxSearcherPokemon</tabstop>
   <tabstop>checkBoxSearcherFeebasTile</tabstop>
+  <tabstop>spinBoxSearcherLevelMin</tabstop>
+  <tabstop>spinBoxSearcherLevelMax</tabstop>
   <tabstop>tableViewSearcher</tabstop>
  </tabstops>
  <resources/>

--- a/Form/Gen4/Eggs4.cpp
+++ b/Form/Gen4/Eggs4.cpp
@@ -64,8 +64,9 @@ Eggs4::Eggs4(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs4)
     ui->textBoxSearcherMinDelay->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxDelay->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->eggSettingsGenerator->setup(Game::Gen4);
     ui->eggSettingsSearcher->setup(Game::Gen4);
@@ -176,7 +177,7 @@ void Eggs4::generate()
         box.exec();
         return;
     }
-    
+
     if (!ui->filterGenerator->isValid())
     {
         return;
@@ -219,7 +220,7 @@ void Eggs4::search()
         box.exec();
         return;
     }
-    
+
     if (!ui->filterSearcher->isValid())
     {
         return;

--- a/Form/Gen4/Event4.cpp
+++ b/Form/Gen4/Event4.cpp
@@ -63,9 +63,9 @@ Event4::Event4(QWidget *parent) : QWidget(parent), ui(new Ui::Event4)
     ui->comboBoxSearcherNature->addItems(Translator::getNatures());
 
     ui->filterGenerator->disableControls(Controls::Ability | Controls::EncounterSlots | Controls::Gender | Controls::Height
-                                         | Controls::Natures | Controls::Shiny | Controls::Weight);
+                                         | Controls::Level | Controls::Natures | Controls::Shiny | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::Ability | Controls::DisableFilter | Controls::EncounterSlots | Controls::Gender
-                                        | Controls::Height | Controls::Natures | Controls::Shiny | Controls::Weight);
+                                        | Controls::Height | Controls::Level | Controls::Natures | Controls::Shiny | Controls::Weight);
 
     ui->filterGenerator->enableHiddenAbility();
     ui->filterSearcher->enableHiddenAbility();

--- a/Form/Gen4/Static4.cpp
+++ b/Form/Gen4/Static4.cpp
@@ -60,8 +60,9 @@ Static4::Static4(QWidget *parent) : QWidget(parent), ui(new Ui::Static4)
     ui->textBoxSearcherMinAdvance->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvance->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"),

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -32,7 +32,6 @@
 #include <Core/Util/Nature.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
-#include <Form/Controls/Filter.hpp>
 #include <Form/Gen4/Profile/ProfileManager4.hpp>
 #include <Form/Gen4/Tools/SeedToTime4.hpp>
 #include <Model/Gen4/WildModel4.hpp>
@@ -41,11 +40,6 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-
-static bool validLevelRange(const Filter *filter, int min, int max)
-{
-    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
-}
 
 Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 {
@@ -341,15 +335,8 @@ void Wild4::updateEncounterSearcher()
 
 void Wild4::generate()
 {
-    if (!ui->filterGenerator->isValid())
+    if (!ui->filterGenerator->isValid(ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -602,6 +589,7 @@ void Wild4::generatorPokemonIndexChanged(int index)
         ui->filterGenerator->resetEncounterSlots();
         ui->spinBoxGeneratorLevelMin->setValue(0);
         ui->spinBoxGeneratorLevelMax->setValue(0);
+        ui->filterGenerator->setLevelRange(1, 100);
     }
     else
     {
@@ -612,6 +600,7 @@ void Wild4::generatorPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxGeneratorLevelMin->setValue(range.first);
         ui->spinBoxGeneratorLevelMax->setValue(range.second);
+        ui->filterGenerator->setLevelRange(range.first, range.second);
     }
 }
 
@@ -673,15 +662,8 @@ void Wild4::profileManager()
 
 void Wild4::search()
 {
-    if (!ui->filterSearcher->isValid())
+    if (!ui->filterSearcher->isValid(ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -974,6 +956,7 @@ void Wild4::searcherPokemonIndexChanged(int index)
         ui->filterSearcher->resetEncounterSlots();
         ui->spinBoxSearcherLevelMin->setValue(0);
         ui->spinBoxSearcherLevelMax->setValue(0);
+        ui->filterSearcher->setLevelRange(1, 100);
     }
     else
     {
@@ -984,6 +967,7 @@ void Wild4::searcherPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
+        ui->filterSearcher->setLevelRange(range.first, range.second);
     }
 }
 

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -41,6 +41,17 @@
 #include <QThread>
 #include <QTimer>
 
+static bool hasLevelRange(Encounter encounter)
+{
+    return encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
+        || encounter == Encounter::SuperRod;
+}
+
+static std::pair<u8, u8> getLevelRange(const EncounterArea4 &area, u16 specie)
+{
+    return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
+}
+
 Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 {
     ui->setupUi(this);
@@ -65,6 +76,8 @@ Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
+    ui->filterGenerator->setLevelVisible(false);
+    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addAction(tr("Compound Eyes"), toInt(Lead::CompoundEyes));
@@ -333,10 +346,58 @@ void Wild4::updateEncounterSearcher()
     encounterSearcher = Encounters4::getEncounters(encounter, settings, currentProfile);
 }
 
+void Wild4::updateGeneratorLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
+    ui->labelGeneratorLevelRange->setVisible(visible);
+    ui->widgetGeneratorLevelRange->setVisible(visible);
+    ui->filterGenerator->setLevelVisible(visible);
+
+    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
+    {
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
+    ui->spinBoxGeneratorLevelMin->setValue(range.first);
+    ui->spinBoxGeneratorLevelMax->setValue(range.second);
+}
+
+void Wild4::updateSearcherLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
+    ui->labelSearcherLevelRange->setVisible(visible);
+    ui->widgetSearcherLevelRange->setVisible(visible);
+    ui->filterSearcher->setLevelVisible(visible);
+
+    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
+    {
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
+    ui->spinBoxSearcherLevelMin->setValue(range.first);
+    ui->spinBoxSearcherLevelMax->setValue(range.second);
+}
+
 void Wild4::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterGenerator->getLevel();
+    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -466,6 +527,7 @@ void Wild4::generatorEncounterIndexChanged(int index)
 
         ui->comboBoxGeneratorLocation->clear();
         ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), !bug);
+        updateGeneratorLevelRange();
     }
 }
 
@@ -577,6 +639,7 @@ void Wild4::generatorLocationIndexChanged(int index)
             ui->checkBoxGeneratorFeebasTile->setVisible(false);
             ui->checkBoxGeneratorFeebasTile->setChecked(false);
         }
+        updateGeneratorLevelRange();
     }
 }
 
@@ -592,6 +655,7 @@ void Wild4::generatorPokemonIndexChanged(int index)
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
     }
+    updateGeneratorLevelRange();
 }
 
 void Wild4::generatorPokeRadarStateChanged(Qt::CheckState state)
@@ -654,6 +718,14 @@ void Wild4::search()
 {
     if (!ui->filterSearcher->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterSearcher->getLevel();
+    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -826,6 +898,7 @@ void Wild4::searcherEncounterIndexChanged(int index)
 
         ui->comboBoxSearcherLocation->clear();
         ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), !bug);
+        updateSearcherLevelRange();
     }
 }
 
@@ -934,6 +1007,7 @@ void Wild4::searcherLocationIndexChanged(int index)
             ui->checkBoxSearcherFeebasTile->setVisible(false);
             ui->checkBoxSearcherFeebasTile->setChecked(false);
         }
+        updateSearcherLevelRange();
     }
 }
 
@@ -949,6 +1023,7 @@ void Wild4::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
     }
+    updateSearcherLevelRange();
 }
 
 void Wild4::searcherPokeRadarStateChanged(Qt::CheckState state)

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -41,25 +41,6 @@
 #include <QThread>
 #include <QTimer>
 
-static bool hasLevelRange(Encounter encounter)
-{
-    return encounter == Encounter::HoneyTree || encounter == Encounter::RockSmash || encounter == Encounter::BugCatchingContest
-        || encounter == Encounter::Headbutt || encounter == Encounter::HeadbuttAlt || encounter == Encounter::HeadbuttSpecial
-        || encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
-        || encounter == Encounter::SuperRod;
-}
-
-static std::pair<u8, u8> getLevelRange(const EncounterArea4 &area, u16 specie)
-{
-    return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
-}
-
-static int findLocationName(const std::vector<std::string> &locations, const QString &location)
-{
-    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
-    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
-}
-
 Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 {
     ui->setupUi(this);
@@ -84,8 +65,6 @@ Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
-    ui->filterGenerator->setLevelVisible(false);
-    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addAction(tr("Compound Eyes"), toInt(Lead::CompoundEyes));
@@ -354,58 +333,10 @@ void Wild4::updateEncounterSearcher()
     encounterSearcher = Encounters4::getEncounters(encounter, settings, currentProfile);
 }
 
-void Wild4::updateGeneratorLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
-    ui->labelGeneratorLevelRange->setVisible(visible);
-    ui->widgetGeneratorLevelRange->setVisible(visible);
-    ui->filterGenerator->setLevelVisible(visible);
-
-    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
-    {
-        ui->spinBoxGeneratorLevelMin->setValue(0);
-        ui->spinBoxGeneratorLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
-    ui->spinBoxGeneratorLevelMin->setValue(range.first);
-    ui->spinBoxGeneratorLevelMax->setValue(range.second);
-}
-
-void Wild4::updateSearcherLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
-    ui->labelSearcherLevelRange->setVisible(visible);
-    ui->widgetSearcherLevelRange->setVisible(visible);
-    ui->filterSearcher->setLevelVisible(visible);
-
-    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
-    {
-        ui->spinBoxSearcherLevelMin->setValue(0);
-        ui->spinBoxSearcherLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
-    ui->spinBoxSearcherLevelMin->setValue(range.first);
-    ui->spinBoxSearcherLevelMax->setValue(range.second);
-}
-
 void Wild4::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
-        return;
-    }
-
-    u8 level = ui->filterGenerator->getLevel();
-    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -482,8 +413,7 @@ void Wild4::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxGeneratorLocation->getCurrentUShort();
 
         bool bug = encounter == Encounter::BugCatchingContest;
         bool fish = encounter == Encounter::OldRod || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
@@ -536,14 +466,8 @@ void Wild4::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea4 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxGeneratorLocation->addItems(locations, !bug);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
-        }
-        updateGeneratorLevelRange();
+        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxGeneratorLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -655,7 +579,6 @@ void Wild4::generatorLocationIndexChanged(int index)
             ui->checkBoxGeneratorFeebasTile->setVisible(false);
             ui->checkBoxGeneratorFeebasTile->setChecked(false);
         }
-        updateGeneratorLevelRange();
     }
 }
 
@@ -664,14 +587,19 @@ void Wild4::generatorPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterGenerator->resetEncounterSlots();
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxGeneratorPokemon->getCurrentUShort();
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxGeneratorLevelMin->setValue(range.first);
+        ui->spinBoxGeneratorLevelMax->setValue(range.second);
     }
-    updateGeneratorLevelRange();
 }
 
 void Wild4::generatorPokeRadarStateChanged(Qt::CheckState state)
@@ -734,14 +662,6 @@ void Wild4::search()
 {
     if (!ui->filterSearcher->isValid())
     {
-        return;
-    }
-
-    u8 level = ui->filterSearcher->getLevel();
-    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -861,8 +781,7 @@ void Wild4::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxSearcherLocation->getCurrentUShort();
 
         bool bug = encounter == Encounter::BugCatchingContest;
         bool fish = encounter == Encounter::OldRod || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
@@ -915,14 +834,8 @@ void Wild4::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea4 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxSearcherLocation->addItems(locations, !bug);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
-        }
-        updateSearcherLevelRange();
+        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxSearcherLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -1031,7 +944,6 @@ void Wild4::searcherLocationIndexChanged(int index)
             ui->checkBoxSearcherFeebasTile->setVisible(false);
             ui->checkBoxSearcherFeebasTile->setChecked(false);
         }
-        updateSearcherLevelRange();
     }
 }
 
@@ -1040,14 +952,19 @@ void Wild4::searcherPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterSearcher->resetEncounterSlots();
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxSearcherPokemon->getCurrentUShort();
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxSearcherLevelMin->setValue(range.first);
+        ui->spinBoxSearcherLevelMax->setValue(range.second);
     }
-    updateSearcherLevelRange();
 }
 
 void Wild4::searcherPokeRadarStateChanged(Qt::CheckState state)

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -54,6 +54,12 @@ static std::pair<u8, u8> getLevelRange(const EncounterArea4 &area, u16 specie)
     return specie == 0 ? std::pair<u8, u8> { 0, 0 } : area.getLevelRange(specie);
 }
 
+static int findLocationName(const std::vector<std::string> &locations, const QString &location)
+{
+    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
+    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
+}
+
 Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 {
     ui->setupUi(this);
@@ -476,6 +482,8 @@ void Wild4::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
 
         bool bug = encounter == Encounter::BugCatchingContest;
         bool fish = encounter == Encounter::OldRod || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
@@ -528,7 +536,13 @@ void Wild4::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea4 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), !bug);
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxGeneratorLocation->addItems(locations, !bug);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
+        }
         updateGeneratorLevelRange();
     }
 }
@@ -847,6 +861,8 @@ void Wild4::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
 
         bool bug = encounter == Encounter::BugCatchingContest;
         bool fish = encounter == Encounter::OldRod || encounter == Encounter::GoodRod || encounter == Encounter::SuperRod;
@@ -899,7 +915,13 @@ void Wild4::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea4 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), !bug);
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxSearcherLocation->addItems(locations, !bug);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
+        }
         updateSearcherLevelRange();
     }
 }

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -43,7 +43,9 @@
 
 static bool hasLevelRange(Encounter encounter)
 {
-    return encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
+    return encounter == Encounter::HoneyTree || encounter == Encounter::RockSmash || encounter == Encounter::BugCatchingContest
+        || encounter == Encounter::Headbutt || encounter == Encounter::HeadbuttAlt || encounter == Encounter::HeadbuttSpecial
+        || encounter == Encounter::Surfing || encounter == Encounter::OldRod || encounter == Encounter::GoodRod
         || encounter == Encounter::SuperRod;
 }
 

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -32,6 +32,7 @@
 #include <Core/Util/Nature.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
+#include <Form/Controls/Filter.hpp>
 #include <Form/Gen4/Profile/ProfileManager4.hpp>
 #include <Form/Gen4/Tools/SeedToTime4.hpp>
 #include <Model/Gen4/WildModel4.hpp>
@@ -40,6 +41,11 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+
+static bool validLevelRange(const Filter *filter, int min, int max)
+{
+    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
+}
 
 Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
 {
@@ -337,6 +343,13 @@ void Wild4::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -662,6 +675,13 @@ void Wild4::search()
 {
     if (!ui->filterSearcher->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -964,7 +964,7 @@ void Wild4::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
 
-        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        auto range = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
         ui->filterSearcher->setLevelRange(range.first, range.second);

--- a/Form/Gen4/Wild4.hpp
+++ b/Form/Gen4/Wild4.hpp
@@ -85,16 +85,6 @@ private:
      */
     void updateEncounterSearcher();
 
-    /**
-     * @brief Updates the displayed level range for the generator tab
-     */
-    void updateGeneratorLevelRange() const;
-
-    /**
-     * @brief Updates the displayed level range for the searcher tab
-     */
-    void updateSearcherLevelRange() const;
-
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen4/Wild4.hpp
+++ b/Form/Gen4/Wild4.hpp
@@ -85,6 +85,16 @@ private:
      */
     void updateEncounterSearcher();
 
+    /**
+     * @brief Updates the displayed level range for the generator tab
+     */
+    void updateGeneratorLevelRange() const;
+
+    /**
+     * @brief Updates the displayed level range for the searcher tab
+     */
+    void updateSearcherLevelRange() const;
+
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen4/Wild4.ui
+++ b/Form/Gen4/Wild4.ui
@@ -480,75 +480,32 @@
           <item row="12" column="3">
            <widget class="QSpinBox" name="spinBoxGeneratorWaterBlock"/>
           </item>
-          <item row="13" column="0" colspan="2">
-           <widget class="QLabel" name="labelGeneratorLevelRange">
-            <property name="text">
-             <string>Level Range</string>
+          <item row="13" column="0" colspan="4">
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="13" column="2" colspan="2">
-           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="14" column="0">
+           <widget class="QLabel" name="labelGeneratorLevel">
+            <property name="text">
+             <string>Levels</string>
             </property>
-            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelGeneratorLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelGeneratorLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
+           </widget>
+          </item>
+          <item row="14" column="2">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="3">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -990,75 +947,32 @@
           <item row="12" column="3">
            <widget class="QSpinBox" name="spinBoxSearcherWaterBlock"/>
           </item>
-          <item row="13" column="0" colspan="2">
-           <widget class="QLabel" name="labelSearcherLevelRange">
-            <property name="text">
-             <string>Level Range</string>
+          <item row="13" column="0" colspan="4">
+           <widget class="Line" name="line_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="13" column="2" colspan="2">
-           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="14" column="0">
+           <widget class="QLabel" name="labelSearcherLevel">
+            <property name="text">
+             <string>Levels</string>
             </property>
-            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelSearcherLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelSearcherLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
+           </widget>
+          </item>
+          <item row="14" column="2">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="3">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -1127,11 +1041,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ComboBox</class>
-   <extends>QComboBox</extends>
-   <header>Form/Controls/ComboBox.hpp</header>
-  </customwidget>
-  <customwidget>
    <class>ComboMenu</class>
    <extends>QToolButton</extends>
    <header>Form/Controls/ComboMenu.hpp</header>
@@ -1158,8 +1067,8 @@
   <tabstop>comboBoxGeneratorPokemon</tabstop>
   <tabstop>comboBoxGeneratorTime</tabstop>
   <tabstop>comboBoxGeneratorHappiness</tabstop>
-  <tabstop>checkBoxGeneratorDualSlot</tabstop>
   <tabstop>comboBoxGeneratorDualSlot</tabstop>
+  <tabstop>checkBoxGeneratorDualSlot</tabstop>
   <tabstop>checkBoxGeneratorFeebasTile</tabstop>
   <tabstop>checkBoxGeneratorPokeRadar</tabstop>
   <tabstop>checkBoxGeneratorRadio</tabstop>
@@ -1172,6 +1081,8 @@
   <tabstop>spinBoxGeneratorForestBlock</tabstop>
   <tabstop>spinBoxGeneratorPeakBlock</tabstop>
   <tabstop>spinBoxGeneratorWaterBlock</tabstop>
+  <tabstop>spinBoxGeneratorLevelMin</tabstop>
+  <tabstop>spinBoxGeneratorLevelMax</tabstop>
   <tabstop>tableViewGenerator</tabstop>
   <tabstop>comboMenuSearcherLead</tabstop>
   <tabstop>checkBoxSearcherPokeRadarShiny</tabstop>
@@ -1200,6 +1111,8 @@
   <tabstop>spinBoxSearcherForestBlock</tabstop>
   <tabstop>spinBoxSearcherPeakBlock</tabstop>
   <tabstop>spinBoxSearcherWaterBlock</tabstop>
+  <tabstop>spinBoxSearcherLevelMin</tabstop>
+  <tabstop>spinBoxSearcherLevelMax</tabstop>
   <tabstop>tableViewSearcher</tabstop>
  </tabstops>
  <resources/>

--- a/Form/Gen4/Wild4.ui
+++ b/Form/Gen4/Wild4.ui
@@ -480,6 +480,77 @@
           <item row="12" column="3">
            <widget class="QSpinBox" name="spinBoxGeneratorWaterBlock"/>
           </item>
+          <item row="13" column="0" colspan="2">
+           <widget class="QLabel" name="labelGeneratorLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="2" colspan="2">
+           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelGeneratorLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelGeneratorLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -918,6 +989,77 @@
           </item>
           <item row="12" column="3">
            <widget class="QSpinBox" name="spinBoxSearcherWaterBlock"/>
+          </item>
+          <item row="13" column="0" colspan="2">
+           <widget class="QLabel" name="labelSearcherLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="2" colspan="2">
+           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelSearcherLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelSearcherLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/Form/Gen5/DreamRadar.cpp
+++ b/Form/Gen5/DreamRadar.cpp
@@ -111,9 +111,9 @@ DreamRadar::DreamRadar(QWidget *parent) : QWidget(parent), ui(new Ui::DreamRadar
     ui->textBoxSearcherMaxAdvances->setValues(InputType::Advance32Bit);
 
     ui->filterGenerator->disableControls(Controls::Ability | Controls::EncounterSlots | Controls::Gender | Controls::Height
-                                         | Controls::Shiny | Controls::Weight);
+                                         | Controls::Level | Controls::Shiny | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::Ability | Controls::DisableFilter | Controls::EncounterSlots | Controls::Gender
-                                        | Controls::Height | Controls::Shiny | Controls::Weight);
+                                        | Controls::Height | Controls::Level | Controls::Shiny | Controls::Weight);
 
     ui->comboBoxGeneratorSpecie1->enableAutoComplete();
     ui->comboBoxGeneratorSpecie2->enableAutoComplete();
@@ -235,7 +235,7 @@ void DreamRadar::updateProfiles()
     profiles.clear();
     auto completeProfiles = ProfileLoader5::getProfiles();
     std::ranges::copy_if(completeProfiles, std::back_inserter(profiles),
-                 [](const Profile5 &profile) { return (profile.getVersion() & Game::BW2) != Game::None; });
+                         [](const Profile5 &profile) { return (profile.getVersion() & Game::BW2) != Game::None; });
 
     ui->comboBoxProfiles->clear();
     for (const auto &profile : profiles)

--- a/Form/Gen5/Eggs5.cpp
+++ b/Form/Gen5/Eggs5.cpp
@@ -56,8 +56,9 @@ Eggs5::Eggs5(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs5)
     ui->textBoxSearcherInitialAdvances->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvances->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->eggSettingsGenerator->setup(Game::Gen5);
     ui->eggSettingsSearcher->setup(Game::Gen5);

--- a/Form/Gen5/Event5.cpp
+++ b/Form/Gen5/Event5.cpp
@@ -69,8 +69,9 @@ Event5::Event5(QWidget *parent) : QWidget(parent), ui(new Ui::Event5)
     ui->comboBoxGeneratorShiny->setup({ toInt(Shiny::Never), toInt(Shiny::Random), toInt(Shiny::Always) });
     ui->comboBoxSearcherShiny->setup({ toInt(Shiny::Never), toInt(Shiny::Random), toInt(Shiny::Always) });
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->filterGenerator->enableHiddenAbility();
     ui->filterSearcher->enableHiddenAbility();

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -34,6 +34,7 @@
 #include <Core/Parents/ProfileLoader.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
+#include <Form/Controls/Filter.hpp>
 #include <Form/Gen5/Profile/ProfileManager5.hpp>
 #include <Model/Gen5/HiddenGrottoModel.hpp>
 #include <Model/SortFilterProxyModel.hpp>
@@ -42,6 +43,11 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+
+static bool validLevelRange(const Filter *filter, int min, int max)
+{
+    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
+}
 
 HiddenGrotto::HiddenGrotto(QWidget *parent) :
     QWidget(parent), ui(new Ui::HiddenGrotto), ivCache(nullptr), shaCache(nullptr), encounter(Encounters5::getHiddenGrottoEncounters())
@@ -464,6 +470,14 @@ void HiddenGrotto::pokemonGenerate()
         return;
     }
 
+    if (!validLevelRange(ui->filterPokemonGenerator, ui->spinBoxPokemonGeneratorLevelMin->value(),
+                         ui->spinBoxPokemonGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
+        return;
+    }
+
     pokemonGeneratorModel->clearModel();
 
     u64 seed = ui->textBoxPokemonGeneratorSeed->getULong();
@@ -552,6 +566,14 @@ void HiddenGrotto::pokemonSearch()
 
     if (!ui->filterPokemonSearcher->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterPokemonSearcher, ui->spinBoxPokemonSearcherLevelMin->value(),
+                         ui->spinBoxPokemonSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -93,8 +93,6 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
                                                 | Controls::Shiny | Controls::Weight);
     ui->filterPokemonSearcher->disableControls(Controls::Ability | Controls::DisableFilter | Controls::EncounterSlots | Controls::Gender
                                                | Controls::Height | Controls::Shiny | Controls::Weight);
-    ui->filterPokemonGenerator->setLevelVisible(true);
-    ui->filterPokemonSearcher->setLevelVisible(true);
 
     ui->comboBoxPokemonGeneratorLocation->enableAutoComplete();
     ui->comboBoxPokemonSearcherLocation->enableAutoComplete();
@@ -144,8 +142,6 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
 
     ui->comboBoxPokemonGeneratorLocation->addItems(locations);
     ui->comboBoxPokemonSearcherLocation->addItems(locations);
-    updatePokemonGeneratorLevelRange();
-    updatePokemonSearcherLevelRange();
 
     updateProfiles();
     pokemonSearcherFastSearchChanged();
@@ -468,14 +464,6 @@ void HiddenGrotto::pokemonGenerate()
         return;
     }
 
-    u8 level = ui->filterPokemonGenerator->getLevel();
-    if (level != 0 && (level < ui->spinBoxPokemonGeneratorLevelMin->value() || level > ui->spinBoxPokemonGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
-        return;
-    }
-
     pokemonGeneratorModel->clearModel();
 
     u64 seed = ui->textBoxPokemonGeneratorSeed->getULong();
@@ -496,40 +484,6 @@ void HiddenGrotto::pokemonGenerate()
     pokemonGeneratorModel->addItems(states);
 }
 
-void HiddenGrotto::updatePokemonGeneratorLevelRange() const
-{
-    if (ui->comboBoxPokemonGeneratorLocation->currentIndex() < 0 || ui->comboBoxPokemonGeneratorGroup->currentIndex() < 0
-        || ui->comboBoxPokemonGeneratorPokemon->currentIndex() < 0)
-    {
-        ui->spinBoxPokemonGeneratorLevelMin->setValue(0);
-        ui->spinBoxPokemonGeneratorLevelMax->setValue(0);
-        return;
-    }
-
-    auto pokemon = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()].getPokemon(
-        ui->comboBoxPokemonGeneratorGroup->currentIndex(), ui->comboBoxPokemonGeneratorPokemon->currentIndex());
-
-    ui->spinBoxPokemonGeneratorLevelMin->setValue(pokemon.getMinLevel());
-    ui->spinBoxPokemonGeneratorLevelMax->setValue(pokemon.getMaxLevel());
-}
-
-void HiddenGrotto::updatePokemonSearcherLevelRange() const
-{
-    if (ui->comboBoxPokemonSearcherLocation->currentIndex() < 0 || ui->comboBoxPokemonSearcherGroup->currentIndex() < 0
-        || ui->comboBoxPokemonSearcherPokemon->currentIndex() < 0)
-    {
-        ui->spinBoxPokemonSearcherLevelMin->setValue(0);
-        ui->spinBoxPokemonSearcherLevelMax->setValue(0);
-        return;
-    }
-
-    auto pokemon = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()].getPokemon(
-        ui->comboBoxPokemonSearcherGroup->currentIndex(), ui->comboBoxPokemonSearcherPokemon->currentIndex());
-
-    ui->spinBoxPokemonSearcherLevelMin->setValue(pokemon.getMinLevel());
-    ui->spinBoxPokemonSearcherLevelMax->setValue(pokemon.getMaxLevel());
-}
-
 void HiddenGrotto::pokemonGeneratorGroupIndexChanged(int index)
 {
     if (index >= 0)
@@ -543,7 +497,6 @@ void HiddenGrotto::pokemonGeneratorGroupIndexChanged(int index)
             ui->comboBoxPokemonGeneratorPokemon->addItem(
                 QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
         }
-        updatePokemonGeneratorLevelRange();
     }
 }
 
@@ -552,7 +505,6 @@ void HiddenGrotto::pokemonGeneratorLocationIndexChanged(int index)
     if (index >= 0)
     {
         pokemonGeneratorGroupIndexChanged(ui->comboBoxPokemonGeneratorGroup->currentIndex());
-        updatePokemonGeneratorLevelRange();
     }
 }
 
@@ -581,7 +533,9 @@ void HiddenGrotto::pokemonGeneratorPokemonIndexChanged(int index)
             ui->comboBoxPokemonGeneratorGender->addItem(QString::fromStdString(Translator::getGender(1)), 1);
             break;
         }
-        updatePokemonGeneratorLevelRange();
+        
+        ui->spinBoxPokemonGeneratorLevelMin->setValue(pokemon.getMinLevel());
+        ui->spinBoxPokemonGeneratorLevelMax->setValue(pokemon.getMaxLevel());
     }
 }
 
@@ -598,14 +552,6 @@ void HiddenGrotto::pokemonSearch()
 
     if (!ui->filterPokemonSearcher->isValid())
     {
-        return;
-    }
-
-    u8 level = ui->filterPokemonSearcher->getLevel();
-    if (level != 0 && (level < ui->spinBoxPokemonSearcherLevelMin->value() || level > ui->spinBoxPokemonSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -720,7 +666,6 @@ void HiddenGrotto::pokemonSearcherGroupIndexChanged(int index)
             ui->comboBoxPokemonSearcherPokemon->addItem(
                 QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
         }
-        updatePokemonSearcherLevelRange();
     }
 }
 
@@ -729,7 +674,6 @@ void HiddenGrotto::pokemonSearcherLocationIndexChanged(int index)
     if (index >= 0)
     {
         pokemonSearcherGroupIndexChanged(ui->comboBoxPokemonSearcherGroup->currentIndex());
-        updatePokemonSearcherLevelRange();
     }
 }
 
@@ -758,7 +702,9 @@ void HiddenGrotto::pokemonSearcherPokemonIndexChanged(int index)
             ui->comboBoxPokemonSearcherGender->addItem(QString::fromStdString(Translator::getGender(1)), 1);
             break;
         }
-        updatePokemonSearcherLevelRange();
+
+        ui->spinBoxPokemonSearcherLevelMin->setValue(pokemon.getMinLevel());
+        ui->spinBoxPokemonSearcherLevelMax->setValue(pokemon.getMaxLevel());
     }
 }
 

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -34,7 +34,6 @@
 #include <Core/Parents/ProfileLoader.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
-#include <Form/Controls/Filter.hpp>
 #include <Form/Gen5/Profile/ProfileManager5.hpp>
 #include <Model/Gen5/HiddenGrottoModel.hpp>
 #include <Model/SortFilterProxyModel.hpp>
@@ -43,11 +42,6 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-
-static bool validLevelRange(const Filter *filter, int min, int max)
-{
-    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
-}
 
 HiddenGrotto::HiddenGrotto(QWidget *parent) :
     QWidget(parent), ui(new Ui::HiddenGrotto), ivCache(nullptr), shaCache(nullptr), encounter(Encounters5::getHiddenGrottoEncounters())
@@ -465,16 +459,8 @@ void HiddenGrotto::grottoSearcherUpdateFilter()
 
 void HiddenGrotto::pokemonGenerate()
 {
-    if (!ui->filterPokemonGenerator->isValid())
+    if (!ui->filterPokemonGenerator->isValid(ui->spinBoxPokemonGeneratorLevelMin->value(), ui->spinBoxPokemonGeneratorLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterPokemonGenerator, ui->spinBoxPokemonGeneratorLevelMin->value(),
-                         ui->spinBoxPokemonGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -547,9 +533,10 @@ void HiddenGrotto::pokemonGeneratorPokemonIndexChanged(int index)
             ui->comboBoxPokemonGeneratorGender->addItem(QString::fromStdString(Translator::getGender(1)), 1);
             break;
         }
-        
+
         ui->spinBoxPokemonGeneratorLevelMin->setValue(pokemon.getMinLevel());
         ui->spinBoxPokemonGeneratorLevelMax->setValue(pokemon.getMaxLevel());
+        ui->filterPokemonGenerator->setLevelRange(pokemon.getMinLevel(), pokemon.getMaxLevel());
     }
 }
 
@@ -564,16 +551,8 @@ void HiddenGrotto::pokemonSearch()
         return;
     }
 
-    if (!ui->filterPokemonSearcher->isValid())
+    if (!ui->filterPokemonSearcher->isValid(ui->spinBoxPokemonSearcherLevelMin->value(), ui->spinBoxPokemonSearcherLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterPokemonSearcher, ui->spinBoxPokemonSearcherLevelMin->value(),
-                         ui->spinBoxPokemonSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -727,6 +706,7 @@ void HiddenGrotto::pokemonSearcherPokemonIndexChanged(int index)
 
         ui->spinBoxPokemonSearcherLevelMin->setValue(pokemon.getMinLevel());
         ui->spinBoxPokemonSearcherLevelMax->setValue(pokemon.getMaxLevel());
+        ui->filterPokemonSearcher->setLevelRange(pokemon.getMinLevel(), pokemon.getMaxLevel());
     }
 }
 

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -93,6 +93,8 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
                                                 | Controls::Shiny | Controls::Weight);
     ui->filterPokemonSearcher->disableControls(Controls::Ability | Controls::DisableFilter | Controls::EncounterSlots | Controls::Gender
                                                | Controls::Height | Controls::Shiny | Controls::Weight);
+    ui->filterPokemonGenerator->setLevelVisible(true);
+    ui->filterPokemonSearcher->setLevelVisible(true);
 
     ui->comboBoxPokemonGeneratorLocation->enableAutoComplete();
     ui->comboBoxPokemonSearcherLocation->enableAutoComplete();
@@ -142,6 +144,8 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
 
     ui->comboBoxPokemonGeneratorLocation->addItems(locations);
     ui->comboBoxPokemonSearcherLocation->addItems(locations);
+    updatePokemonGeneratorLevelRange();
+    updatePokemonSearcherLevelRange();
 
     updateProfiles();
     pokemonSearcherFastSearchChanged();
@@ -464,6 +468,14 @@ void HiddenGrotto::pokemonGenerate()
         return;
     }
 
+    u8 level = ui->filterPokemonGenerator->getLevel();
+    if (level != 0 && (level < ui->spinBoxPokemonGeneratorLevelMin->value() || level > ui->spinBoxPokemonGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
+        return;
+    }
+
     pokemonGeneratorModel->clearModel();
 
     u64 seed = ui->textBoxPokemonGeneratorSeed->getULong();
@@ -484,6 +496,40 @@ void HiddenGrotto::pokemonGenerate()
     pokemonGeneratorModel->addItems(states);
 }
 
+void HiddenGrotto::updatePokemonGeneratorLevelRange() const
+{
+    if (ui->comboBoxPokemonGeneratorLocation->currentIndex() < 0 || ui->comboBoxPokemonGeneratorGroup->currentIndex() < 0
+        || ui->comboBoxPokemonGeneratorPokemon->currentIndex() < 0)
+    {
+        ui->spinBoxPokemonGeneratorLevelMin->setValue(0);
+        ui->spinBoxPokemonGeneratorLevelMax->setValue(0);
+        return;
+    }
+
+    auto pokemon = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()].getPokemon(
+        ui->comboBoxPokemonGeneratorGroup->currentIndex(), ui->comboBoxPokemonGeneratorPokemon->currentIndex());
+
+    ui->spinBoxPokemonGeneratorLevelMin->setValue(pokemon.getMinLevel());
+    ui->spinBoxPokemonGeneratorLevelMax->setValue(pokemon.getMaxLevel());
+}
+
+void HiddenGrotto::updatePokemonSearcherLevelRange() const
+{
+    if (ui->comboBoxPokemonSearcherLocation->currentIndex() < 0 || ui->comboBoxPokemonSearcherGroup->currentIndex() < 0
+        || ui->comboBoxPokemonSearcherPokemon->currentIndex() < 0)
+    {
+        ui->spinBoxPokemonSearcherLevelMin->setValue(0);
+        ui->spinBoxPokemonSearcherLevelMax->setValue(0);
+        return;
+    }
+
+    auto pokemon = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()].getPokemon(
+        ui->comboBoxPokemonSearcherGroup->currentIndex(), ui->comboBoxPokemonSearcherPokemon->currentIndex());
+
+    ui->spinBoxPokemonSearcherLevelMin->setValue(pokemon.getMinLevel());
+    ui->spinBoxPokemonSearcherLevelMax->setValue(pokemon.getMaxLevel());
+}
+
 void HiddenGrotto::pokemonGeneratorGroupIndexChanged(int index)
 {
     if (index >= 0)
@@ -497,6 +543,7 @@ void HiddenGrotto::pokemonGeneratorGroupIndexChanged(int index)
             ui->comboBoxPokemonGeneratorPokemon->addItem(
                 QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
         }
+        updatePokemonGeneratorLevelRange();
     }
 }
 
@@ -505,6 +552,7 @@ void HiddenGrotto::pokemonGeneratorLocationIndexChanged(int index)
     if (index >= 0)
     {
         pokemonGeneratorGroupIndexChanged(ui->comboBoxPokemonGeneratorGroup->currentIndex());
+        updatePokemonGeneratorLevelRange();
     }
 }
 
@@ -533,6 +581,7 @@ void HiddenGrotto::pokemonGeneratorPokemonIndexChanged(int index)
             ui->comboBoxPokemonGeneratorGender->addItem(QString::fromStdString(Translator::getGender(1)), 1);
             break;
         }
+        updatePokemonGeneratorLevelRange();
     }
 }
 
@@ -549,6 +598,14 @@ void HiddenGrotto::pokemonSearch()
 
     if (!ui->filterPokemonSearcher->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterPokemonSearcher->getLevel();
+    if (level != 0 && (level < ui->spinBoxPokemonSearcherLevelMin->value() || level > ui->spinBoxPokemonSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -663,6 +720,7 @@ void HiddenGrotto::pokemonSearcherGroupIndexChanged(int index)
             ui->comboBoxPokemonSearcherPokemon->addItem(
                 QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
         }
+        updatePokemonSearcherLevelRange();
     }
 }
 
@@ -671,6 +729,7 @@ void HiddenGrotto::pokemonSearcherLocationIndexChanged(int index)
     if (index >= 0)
     {
         pokemonSearcherGroupIndexChanged(ui->comboBoxPokemonSearcherGroup->currentIndex());
+        updatePokemonSearcherLevelRange();
     }
 }
 
@@ -699,6 +758,7 @@ void HiddenGrotto::pokemonSearcherPokemonIndexChanged(int index)
             ui->comboBoxPokemonSearcherGender->addItem(QString::fromStdString(Translator::getGender(1)), 1);
             break;
         }
+        updatePokemonSearcherLevelRange();
     }
 }
 

--- a/Form/Gen5/HiddenGrotto.hpp
+++ b/Form/Gen5/HiddenGrotto.hpp
@@ -140,6 +140,16 @@ private slots:
     void pokemonGenerate();
 
     /**
+     * @brief Updates the displayed level range for the pokemon generator tab
+     */
+    void updatePokemonGeneratorLevelRange() const;
+
+    /**
+     * @brief Updates the displayed level range for the pokemon searcher tab
+     */
+    void updatePokemonSearcherLevelRange() const;
+
+    /**
      * @brief Updates the group listed
      *
      * @param index Group index

--- a/Form/Gen5/HiddenGrotto.hpp
+++ b/Form/Gen5/HiddenGrotto.hpp
@@ -140,16 +140,6 @@ private slots:
     void pokemonGenerate();
 
     /**
-     * @brief Updates the displayed level range for the pokemon generator tab
-     */
-    void updatePokemonGeneratorLevelRange() const;
-
-    /**
-     * @brief Updates the displayed level range for the pokemon searcher tab
-     */
-    void updatePokemonSearcherLevelRange() const;
-
-    /**
      * @brief Updates the group listed
      *
      * @param index Group index

--- a/Form/Gen5/HiddenGrotto.ui
+++ b/Form/Gen5/HiddenGrotto.ui
@@ -969,6 +969,71 @@
               <item row="3" column="1">
                <widget class="ComboBox" name="comboBoxPokemonGeneratorGender"/>
               </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="labelPokemonGeneratorLevelRange">
+                <property name="text">
+                 <string>Level Range</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QWidget" name="widgetPokemonGeneratorLevelRange" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <layout class="QGridLayout" name="gridLayoutPokemonGeneratorLevelRange">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="labelPokemonGeneratorLevelMin">
+                   <property name="text">
+                    <string>Min</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="labelPokemonGeneratorLevelMax">
+                   <property name="text">
+                    <string>Max</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QSpinBox" name="spinBoxPokemonGeneratorLevelMin">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximum">
+                    <number>100</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QSpinBox" name="spinBoxPokemonGeneratorLevelMax">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximum">
+                    <number>100</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>
@@ -1195,14 +1260,79 @@
               <item row="3" column="1" colspan="2">
                <widget class="ComboBox" name="comboBoxPokemonSearcherGender"/>
               </item>
-              <item row="4" column="0" colspan="3">
+              <item row="4" column="0">
+               <widget class="QLabel" name="labelPokemonSearcherLevelRange">
+                <property name="text">
+                 <string>Level Range</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1" colspan="2">
+               <widget class="QWidget" name="widgetPokemonSearcherLevelRange" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <layout class="QGridLayout" name="gridLayoutPokemonSearcherLevelRange">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="labelPokemonSearcherLevelMin">
+                   <property name="text">
+                    <string>Min</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="labelPokemonSearcherLevelMax">
+                   <property name="text">
+                    <string>Max</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QSpinBox" name="spinBoxPokemonSearcherLevelMin">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximum">
+                    <number>100</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QSpinBox" name="spinBoxPokemonSearcherLevelMax">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximum">
+                    <number>100</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="5" column="0" colspan="3">
                <widget class="Line" name="line_5">
                 <property name="orientation">
                  <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="3">
+              <item row="6" column="0" colspan="3">
                <widget class="QLabel" name="labelPokemonSearcherIVFastSearch">
                 <property name="text">
                  <string/>

--- a/Form/Gen5/Static5.cpp
+++ b/Form/Gen5/Static5.cpp
@@ -64,8 +64,9 @@ Static5::Static5(QWidget *parent) : QWidget(parent), ui(new Ui::Static5), ivCach
     ui->textBoxSearcherInitialAdvances->setValues(InputType::Advance32Bit);
     ui->textBoxSearcherMaxAdvances->setValues(InputType::Advance32Bit);
 
-    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
-    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filterGenerator->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
+    ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::EncounterSlots | Controls::Height | Controls::Level
+                                        | Controls::Weight);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addMenu(tr("Cute Charm"),

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -34,6 +34,7 @@
 #include <Core/Parents/ProfileLoader.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
+#include <Form/Controls/Filter.hpp>
 #include <Form/Gen5/Profile/ProfileManager5.hpp>
 #include <Model/Gen5/WildModel5.hpp>
 #include <Model/SortFilterProxyModel.hpp>
@@ -42,6 +43,11 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+
+static bool validLevelRange(const Filter *filter, int min, int max)
+{
+    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
+}
 
 Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(nullptr), shaCache(nullptr)
 {
@@ -219,6 +225,13 @@ void Wild5::generate()
         return;
     }
 
+    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
+        return;
+    }
+
     generatorModel->clearModel();
 
     u64 seed = ui->textBoxGeneratorSeed->getULong();
@@ -385,6 +398,13 @@ void Wild5::search()
 
     if (!ui->filterSearcher->isValid())
     {
+        return;
+    }
+
+    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
+        msg.exec();
         return;
     }
 

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -76,6 +76,12 @@ static std::pair<u8, u8> getLevelRange(const EncounterArea5 &area, u16 specie)
     return range;
 }
 
+static int findLocationName(const std::vector<std::string> &locations, const QString &location)
+{
+    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
+    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
+}
+
 Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(nullptr), shaCache(nullptr)
 {
     ui->setupUi(this);
@@ -325,6 +331,8 @@ void Wild5::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
 
         u8 season = ui->comboBoxGeneratorSeason->currentIndex();
         encounterGenerator = Encounters5::getEncounters(encounter, season, currentProfile);
@@ -333,7 +341,13 @@ void Wild5::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea5 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxGeneratorLocation->addItems(locations);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
+        }
         updateGeneratorLevelRange();
     }
 }
@@ -543,6 +557,8 @@ void Wild5::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
+        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
+        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
 
         u8 season = ui->comboBoxSearcherSeason->currentIndex();
         encounterSearcher = Encounters5::getEncounters(encounter, season, currentProfile);
@@ -551,7 +567,13 @@ void Wild5::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea5 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
+        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
+        ui->comboBoxSearcherLocation->addItems(locations);
+        if (locationIndex >= 0)
+        {
+            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
+        }
         updateSearcherLevelRange();
     }
 }

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -42,6 +42,39 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+#include <algorithm>
+
+static bool hasLevelRange(Encounter encounter)
+{
+    return encounter == Encounter::Surfing || encounter == Encounter::SurfingRippling || encounter == Encounter::SuperRod
+        || encounter == Encounter::SuperRodRippling;
+}
+
+static std::pair<u8, u8> getLevelRange(const EncounterArea5 &area, u16 specie)
+{
+    if (specie == 0)
+    {
+        return { 0, 0 };
+    }
+
+    std::pair<u8, u8> range = { 100, 0 };
+    for (u8 i = 0; i < area.getCount(); i++)
+    {
+        const auto &slot = area.getPokemon(i);
+        if (slot.getSpecie() == (specie & 0x7ff) && slot.getForm() == (specie >> 11))
+        {
+            range.first = std::min(range.first, slot.getMinLevel());
+            range.second = std::max(range.second, slot.getMaxLevel());
+        }
+    }
+
+    if (range.first == 100)
+    {
+        return { 0, 0 };
+    }
+
+    return range;
+}
 
 Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(nullptr), shaCache(nullptr)
 {
@@ -75,6 +108,8 @@ Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(null
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
+    ui->filterGenerator->setLevelVisible(false);
+    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addAction(tr("Compound Eyes"), toInt(Lead::CompoundEyes));
@@ -212,10 +247,58 @@ bool Wild5::fastSearchEnabled() const
     return min[0] >= 30 && min[2] >= 30 && min[4] >= 30 && (min[1] >= 30 || min[3] >= 30) && (min[5] >= 30 || max[5] <= 1);
 }
 
+void Wild5::updateGeneratorLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
+    ui->labelGeneratorLevelRange->setVisible(visible);
+    ui->widgetGeneratorLevelRange->setVisible(visible);
+    ui->filterGenerator->setLevelVisible(visible);
+
+    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
+    {
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
+    ui->spinBoxGeneratorLevelMin->setValue(range.first);
+    ui->spinBoxGeneratorLevelMax->setValue(range.second);
+}
+
+void Wild5::updateSearcherLevelRange() const
+{
+    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
+    ui->labelSearcherLevelRange->setVisible(visible);
+    ui->widgetSearcherLevelRange->setVisible(visible);
+    ui->filterSearcher->setLevelVisible(visible);
+
+    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
+    {
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
+        return;
+    }
+
+    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
+    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
+    ui->spinBoxSearcherLevelMin->setValue(range.first);
+    ui->spinBoxSearcherLevelMax->setValue(range.second);
+}
+
 void Wild5::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
+        return;
+    }
+
+    u8 level = ui->filterGenerator->getLevel();
+    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
         return;
     }
 
@@ -251,6 +334,7 @@ void Wild5::generatorEncounterIndexChanged(int index)
 
         ui->comboBoxGeneratorLocation->clear();
         ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        updateGeneratorLevelRange();
     }
 }
 
@@ -270,6 +354,7 @@ void Wild5::generatorLocationIndexChanged(int index)
         {
             ui->comboBoxGeneratorPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
+        updateGeneratorLevelRange();
     }
 }
 
@@ -285,6 +370,7 @@ void Wild5::generatorPokemonIndexChanged(int index)
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
     }
+    updateGeneratorLevelRange();
 }
 
 void Wild5::generatorSeasonIndexChanged(int index)
@@ -380,6 +466,14 @@ void Wild5::search()
         return;
     }
 
+    u8 level = ui->filterSearcher->getLevel();
+    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
+    {
+        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
+        msg.exec();
+        return;
+    }
+
     searcherModel->clearModel();
 
     ui->pushButtonSearch->setEnabled(false);
@@ -458,6 +552,7 @@ void Wild5::searcherEncounterIndexChanged(int index)
 
         ui->comboBoxSearcherLocation->clear();
         ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        updateSearcherLevelRange();
     }
 }
 
@@ -508,6 +603,7 @@ void Wild5::searcherLocationIndexChanged(int index)
         {
             ui->comboBoxSearcherPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
+        updateSearcherLevelRange();
     }
 }
 
@@ -523,6 +619,7 @@ void Wild5::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
     }
+    updateSearcherLevelRange();
 }
 
 void Wild5::searcherSeasonIndexChanged(int index)

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -538,7 +538,7 @@ void Wild5::searcherPokemonIndexChanged(int index)
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
 
-        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        auto range = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
         ui->filterSearcher->setLevelRange(range.first, range.second);

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -34,7 +34,6 @@
 #include <Core/Parents/ProfileLoader.hpp>
 #include <Core/Util/Translator.hpp>
 #include <Form/Controls/Controls.hpp>
-#include <Form/Controls/Filter.hpp>
 #include <Form/Gen5/Profile/ProfileManager5.hpp>
 #include <Model/Gen5/WildModel5.hpp>
 #include <Model/SortFilterProxyModel.hpp>
@@ -43,11 +42,6 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-
-static bool validLevelRange(const Filter *filter, int min, int max)
-{
-    return min == 0 || max == 0 || (filter->getLevelMin() <= max && filter->getLevelMax() >= min);
-}
 
 Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(nullptr), shaCache(nullptr)
 {
@@ -220,15 +214,8 @@ bool Wild5::fastSearchEnabled() const
 
 void Wild5::generate()
 {
-    if (!ui->filterGenerator->isValid())
+    if (!ui->filterGenerator->isValid(ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterGenerator, ui->spinBoxGeneratorLevelMin->value(), ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -295,6 +282,7 @@ void Wild5::generatorPokemonIndexChanged(int index)
         ui->filterGenerator->resetEncounterSlots();
         ui->spinBoxGeneratorLevelMin->setValue(0);
         ui->spinBoxGeneratorLevelMax->setValue(0);
+        ui->filterGenerator->setLevelRange(1, 100);
     }
     else
     {
@@ -305,6 +293,7 @@ void Wild5::generatorPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxGeneratorLevelMin->setValue(range.first);
         ui->spinBoxGeneratorLevelMax->setValue(range.second);
+        ui->filterGenerator->setLevelRange(range.first, range.second);
     }
 }
 
@@ -396,15 +385,8 @@ void Wild5::search()
         return;
     }
 
-    if (!ui->filterSearcher->isValid())
+    if (!ui->filterSearcher->isValid(ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
     {
-        return;
-    }
-
-    if (!validLevelRange(ui->filterSearcher, ui->spinBoxSearcherLevelMin->value(), ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level filter outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -548,6 +530,7 @@ void Wild5::searcherPokemonIndexChanged(int index)
         ui->filterSearcher->resetEncounterSlots();
         ui->spinBoxSearcherLevelMin->setValue(0);
         ui->spinBoxSearcherLevelMax->setValue(0);
+        ui->filterSearcher->setLevelRange(1, 100);
     }
     else
     {
@@ -558,6 +541,7 @@ void Wild5::searcherPokemonIndexChanged(int index)
         auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxSearcherLevelMin->setValue(range.first);
         ui->spinBoxSearcherLevelMax->setValue(range.second);
+        ui->filterSearcher->setLevelRange(range.first, range.second);
     }
 }
 

--- a/Form/Gen5/Wild5.cpp
+++ b/Form/Gen5/Wild5.cpp
@@ -42,45 +42,6 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
-#include <algorithm>
-
-static bool hasLevelRange(Encounter encounter)
-{
-    return encounter == Encounter::Surfing || encounter == Encounter::SurfingRippling || encounter == Encounter::SuperRod
-        || encounter == Encounter::SuperRodRippling;
-}
-
-static std::pair<u8, u8> getLevelRange(const EncounterArea5 &area, u16 specie)
-{
-    if (specie == 0)
-    {
-        return { 0, 0 };
-    }
-
-    std::pair<u8, u8> range = { 100, 0 };
-    for (u8 i = 0; i < area.getCount(); i++)
-    {
-        const auto &slot = area.getPokemon(i);
-        if (slot.getSpecie() == (specie & 0x7ff) && slot.getForm() == (specie >> 11))
-        {
-            range.first = std::min(range.first, slot.getMinLevel());
-            range.second = std::max(range.second, slot.getMaxLevel());
-        }
-    }
-
-    if (range.first == 100)
-    {
-        return { 0, 0 };
-    }
-
-    return range;
-}
-
-static int findLocationName(const std::vector<std::string> &locations, const QString &location)
-{
-    auto it = std::ranges::find_if(locations, [&location](const std::string &name) { return QString::fromStdString(name) == location; });
-    return it == locations.end() ? -1 : static_cast<int>(it - locations.begin());
-}
 
 Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(nullptr), shaCache(nullptr)
 {
@@ -114,8 +75,6 @@ Wild5::Wild5(QWidget *parent) : QWidget(parent), ui(new Ui::Wild5), ivCache(null
 
     ui->filterGenerator->disableControls(Controls::Height | Controls::Weight);
     ui->filterSearcher->disableControls(Controls::DisableFilter | Controls::Height | Controls::Weight);
-    ui->filterGenerator->setLevelVisible(false);
-    ui->filterSearcher->setLevelVisible(false);
 
     ui->comboMenuGeneratorLead->addAction(tr("None"), toInt(Lead::None));
     ui->comboMenuGeneratorLead->addAction(tr("Compound Eyes"), toInt(Lead::CompoundEyes));
@@ -253,58 +212,10 @@ bool Wild5::fastSearchEnabled() const
     return min[0] >= 30 && min[2] >= 30 && min[4] >= 30 && (min[1] >= 30 || min[3] >= 30) && (min[5] >= 30 || max[5] <= 1);
 }
 
-void Wild5::updateGeneratorLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxGeneratorEncounter->getEnum<Encounter>());
-    ui->labelGeneratorLevelRange->setVisible(visible);
-    ui->widgetGeneratorLevelRange->setVisible(visible);
-    ui->filterGenerator->setLevelVisible(visible);
-
-    if (!visible || encounterGenerator.empty() || ui->comboBoxGeneratorLocation->currentIndex() < 0)
-    {
-        ui->spinBoxGeneratorLevelMin->setValue(0);
-        ui->spinBoxGeneratorLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxGeneratorPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxGeneratorPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()], specie);
-    ui->spinBoxGeneratorLevelMin->setValue(range.first);
-    ui->spinBoxGeneratorLevelMax->setValue(range.second);
-}
-
-void Wild5::updateSearcherLevelRange() const
-{
-    bool visible = hasLevelRange(ui->comboBoxSearcherEncounter->getEnum<Encounter>());
-    ui->labelSearcherLevelRange->setVisible(visible);
-    ui->widgetSearcherLevelRange->setVisible(visible);
-    ui->filterSearcher->setLevelVisible(visible);
-
-    if (!visible || encounterSearcher.empty() || ui->comboBoxSearcherLocation->currentIndex() < 0)
-    {
-        ui->spinBoxSearcherLevelMin->setValue(0);
-        ui->spinBoxSearcherLevelMax->setValue(0);
-        return;
-    }
-
-    u16 specie = ui->comboBoxSearcherPokemon->currentIndex() <= 0 ? 0 : ui->comboBoxSearcherPokemon->getCurrentUShort();
-    auto range = getLevelRange(encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()], specie);
-    ui->spinBoxSearcherLevelMin->setValue(range.first);
-    ui->spinBoxSearcherLevelMax->setValue(range.second);
-}
-
 void Wild5::generate()
 {
     if (!ui->filterGenerator->isValid())
     {
-        return;
-    }
-
-    u8 level = ui->filterGenerator->getLevel();
-    if (level != 0 && (level < ui->spinBoxGeneratorLevelMin->value() || level > ui->spinBoxGeneratorLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
         return;
     }
 
@@ -331,8 +242,7 @@ void Wild5::generatorEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxGeneratorEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterGenerator.empty() && ui->comboBoxGeneratorLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxGeneratorLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxGeneratorLocation->getCurrentUShort();
 
         u8 season = ui->comboBoxGeneratorSeason->currentIndex();
         encounterGenerator = Encounters5::getEncounters(encounter, season, currentProfile);
@@ -341,14 +251,8 @@ void Wild5::generatorEncounterIndexChanged(int index)
         std::ranges::transform(encounterGenerator, std::back_inserter(locs), [](const EncounterArea5 &area) { return area.getLocation(); });
 
         ui->comboBoxGeneratorLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxGeneratorLocation->addItems(locations);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxGeneratorLocation->setCurrentIndex(locationIndex);
-        }
-        updateGeneratorLevelRange();
+        ui->comboBoxGeneratorLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxGeneratorLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -368,7 +272,6 @@ void Wild5::generatorLocationIndexChanged(int index)
         {
             ui->comboBoxGeneratorPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
-        updateGeneratorLevelRange();
     }
 }
 
@@ -377,14 +280,19 @@ void Wild5::generatorPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterGenerator->resetEncounterSlots();
+        ui->spinBoxGeneratorLevelMin->setValue(0);
+        ui->spinBoxGeneratorLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxGeneratorPokemon->getCurrentUShort();
         auto flags = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getSlots(num);
         ui->filterGenerator->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxGeneratorLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxGeneratorLevelMin->setValue(range.first);
+        ui->spinBoxGeneratorLevelMax->setValue(range.second);
     }
-    updateGeneratorLevelRange();
 }
 
 void Wild5::generatorSeasonIndexChanged(int index)
@@ -480,14 +388,6 @@ void Wild5::search()
         return;
     }
 
-    u8 level = ui->filterSearcher->getLevel();
-    if (level != 0 && (level < ui->spinBoxSearcherLevelMin->value() || level > ui->spinBoxSearcherLevelMax->value()))
-    {
-        QMessageBox msg(QMessageBox::Warning, tr("Invalid level"), tr("Level outside of encounters level range!"));
-        msg.exec();
-        return;
-    }
-
     searcherModel->clearModel();
 
     ui->pushButtonSearch->setEnabled(false);
@@ -557,8 +457,7 @@ void Wild5::searcherEncounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxSearcherEncounter->getEnum<Encounter>();
-        bool preserveLocation = !encounterSearcher.empty() && ui->comboBoxSearcherLocation->currentIndex() >= 0;
-        QString locationName = preserveLocation ? ui->comboBoxSearcherLocation->currentText() : QString();
+        u16 currentLocation = ui->comboBoxSearcherLocation->getCurrentUShort();
 
         u8 season = ui->comboBoxSearcherSeason->currentIndex();
         encounterSearcher = Encounters5::getEncounters(encounter, season, currentProfile);
@@ -567,14 +466,8 @@ void Wild5::searcherEncounterIndexChanged(int index)
         std::ranges::transform(encounterSearcher, std::back_inserter(locs), [](const EncounterArea5 &area) { return area.getLocation(); });
 
         ui->comboBoxSearcherLocation->clear();
-        auto locations = Translator::getLocations(locs, currentProfile->getVersion());
-        int locationIndex = preserveLocation ? findLocationName(locations, locationName) : -1;
-        ui->comboBoxSearcherLocation->addItems(locations);
-        if (locationIndex >= 0)
-        {
-            ui->comboBoxSearcherLocation->setCurrentIndex(locationIndex);
-        }
-        updateSearcherLevelRange();
+        ui->comboBoxSearcherLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxSearcherLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -625,7 +518,6 @@ void Wild5::searcherLocationIndexChanged(int index)
         {
             ui->comboBoxSearcherPokemon->addItem(QString::fromStdString(names[i]), species[i]);
         }
-        updateSearcherLevelRange();
     }
 }
 
@@ -634,14 +526,19 @@ void Wild5::searcherPokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filterSearcher->resetEncounterSlots();
+        ui->spinBoxSearcherLevelMin->setValue(0);
+        ui->spinBoxSearcherLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxSearcherPokemon->getCurrentUShort();
         auto flags = encounterSearcher[ui->comboBoxSearcherLocation->currentIndex()].getSlots(num);
         ui->filterSearcher->toggleEncounterSlots(flags);
+
+        auto range = encounterGenerator[ui->comboBoxSearcherLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxSearcherLevelMin->setValue(range.first);
+        ui->spinBoxSearcherLevelMax->setValue(range.second);
     }
-    updateSearcherLevelRange();
 }
 
 void Wild5::searcherSeasonIndexChanged(int index)

--- a/Form/Gen5/Wild5.hpp
+++ b/Form/Gen5/Wild5.hpp
@@ -95,6 +95,16 @@ private:
      */
     bool fastSearchEnabled() const;
 
+    /**
+     * @brief Updates the displayed level range for the generator tab
+     */
+    void updateGeneratorLevelRange() const;
+
+    /**
+     * @brief Updates the displayed level range for the searcher tab
+     */
+    void updateSearcherLevelRange() const;
+
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen5/Wild5.hpp
+++ b/Form/Gen5/Wild5.hpp
@@ -95,16 +95,6 @@ private:
      */
     bool fastSearchEnabled() const;
 
-    /**
-     * @brief Updates the displayed level range for the generator tab
-     */
-    void updateGeneratorLevelRange() const;
-
-    /**
-     * @brief Updates the displayed level range for the searcher tab
-     */
-    void updateSearcherLevelRange() const;
-
 private slots:
     /**
      * @brief Generates wild encounters from a starting seed

--- a/Form/Gen5/Wild5.ui
+++ b/Form/Gen5/Wild5.ui
@@ -319,7 +319,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxGeneratorEncounter">
             <item>
              <property name="text">
@@ -365,7 +365,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="1" column="1" colspan="2">
            <widget class="QComboBox" name="comboBoxGeneratorSeason">
             <item>
              <property name="text">
@@ -396,7 +396,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="2" column="1" colspan="2">
            <widget class="ComboBoxProxy" name="comboBoxGeneratorLocation"/>
           </item>
           <item row="3" column="0">
@@ -406,78 +406,35 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="3" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxGeneratorPokemon"/>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="labelGeneratorLevelRange">
-            <property name="text">
-             <string>Level Range</string>
+          <item row="4" column="0" colspan="3">
+           <widget class="Line" name="line_6">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelGeneratorLevel">
+            <property name="text">
+             <string>Levels</string>
             </property>
-            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelGeneratorLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelGeneratorLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -683,7 +640,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxSearcherEncounter">
             <item>
              <property name="text">
@@ -729,7 +686,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="1" column="1" colspan="2">
            <widget class="QComboBox" name="comboBoxSearcherSeason">
             <item>
              <property name="text">
@@ -760,7 +717,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="2" column="1" colspan="2">
            <widget class="ComboBoxProxy" name="comboBoxSearcherLocation"/>
           </item>
           <item row="3" column="0">
@@ -770,88 +727,45 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="3" column="1" colspan="2">
            <widget class="ComboBox" name="comboBoxSearcherPokemon"/>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="labelSearcherLevelRange">
-            <property name="text">
-             <string>Level Range</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>6</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelSearcherLevelMin">
-               <property name="text">
-                <string>Min</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelSearcherLevelMax">
-               <property name="text">
-                <string>Max</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximum">
-                <number>100</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
+          <item row="4" column="0" colspan="3">
            <widget class="Line" name="line_5">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="2">
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelSearcherLevel">
+            <property name="text">
+             <string>Levels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="3">
+           <widget class="Line" name="line_6">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="3">
            <widget class="QLabel" name="labelIVFastSearch">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -961,6 +875,8 @@
   <tabstop>comboBoxGeneratorSeason</tabstop>
   <tabstop>comboBoxGeneratorLocation</tabstop>
   <tabstop>comboBoxGeneratorPokemon</tabstop>
+  <tabstop>spinBoxGeneratorLevelMin</tabstop>
+  <tabstop>spinBoxGeneratorLevelMax</tabstop>
   <tabstop>tableViewGenerator</tabstop>
   <tabstop>comboMenuSearcherLead</tabstop>
   <tabstop>textBoxSearcherInitialIVAdvances</tabstop>
@@ -976,6 +892,8 @@
   <tabstop>comboBoxSearcherSeason</tabstop>
   <tabstop>comboBoxSearcherLocation</tabstop>
   <tabstop>comboBoxSearcherPokemon</tabstop>
+  <tabstop>spinBoxSearcherLevelMin</tabstop>
+  <tabstop>spinBoxSearcherLevelMax</tabstop>
   <tabstop>tableViewSearcher</tabstop>
  </tabstops>
  <resources/>

--- a/Form/Gen5/Wild5.ui
+++ b/Form/Gen5/Wild5.ui
@@ -409,6 +409,77 @@
           <item row="3" column="1">
            <widget class="ComboBox" name="comboBoxGeneratorPokemon"/>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelGeneratorLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QWidget" name="widgetGeneratorLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutGeneratorLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelGeneratorLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelGeneratorLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxGeneratorLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -701,6 +772,77 @@
           </item>
           <item row="3" column="1">
            <widget class="ComboBox" name="comboBoxSearcherPokemon"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelSearcherLevelRange">
+            <property name="text">
+             <string>Level Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QWidget" name="widgetSearcherLevelRange" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QGridLayout" name="gridLayoutSearcherLevelRange">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>6</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelSearcherLevelMin">
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelSearcherLevelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMin">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="spinBoxSearcherLevelMax">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item row="5" column="0" colspan="2">
            <widget class="Line" name="line_5">

--- a/Form/Gen8/Eggs8.cpp
+++ b/Form/Gen8/Eggs8.cpp
@@ -46,7 +46,7 @@ Eggs8::Eggs8(QWidget *parent) : QWidget(parent), ui(new Ui::Eggs8)
 
     ui->comboBoxCompatibility->setup({ 20, 50, 70 });
 
-    ui->filter->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Weight);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::Height | Controls::Level | Controls::Weight);
 
     ui->eggSettings->setup(Game::BDSP);
 

--- a/Form/Gen8/Event8.cpp
+++ b/Form/Gen8/Event8.cpp
@@ -49,7 +49,7 @@ Event8::Event8(QWidget *parent) : QWidget(parent), ui(new Ui::Event8)
     ui->textBoxEC->setValues(InputType::Seed32Bit);
     ui->textBoxPID->setValues(InputType::Seed32Bit);
 
-    ui->filter->disableControls(Controls::EncounterSlots);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::Level);
 
     ui->filter->enableHiddenAbility();
 

--- a/Form/Gen8/Raids.cpp
+++ b/Form/Gen8/Raids.cpp
@@ -41,7 +41,7 @@ Raids::Raids(QWidget *parent) : QWidget(parent), ui(new Ui::Raids), currentProfi
     model = new StaticModel8(ui->tableView);
     ui->tableView->setModel(model);
 
-    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers | Controls::Level);
     ui->filter->enableHiddenAbility();
 
     ui->comboBoxAbilityType->setup({ 0, 1, 2, 3, 4 });

--- a/Form/Gen8/Static8.cpp
+++ b/Form/Gen8/Static8.cpp
@@ -53,7 +53,7 @@ Static8::Static8(QWidget *parent) : QWidget(parent), ui(new Ui::Static8)
     ui->comboBoxShiny->setup({ toInt(Shiny::Never), toInt(Shiny::Random) });
     ui->comboBoxAbility->setup({ 0, 1, 2, 255 });
 
-    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::HiddenPowers | Controls::Level);
 
     connect(ui->comboBoxProfiles, &QComboBox::currentIndexChanged, this, &Static8::profileIndexChanged);
     connect(ui->pushButtonGenerate, &QPushButton::clicked, this, &Static8::generate);

--- a/Form/Gen8/Underground.cpp
+++ b/Form/Gen8/Underground.cpp
@@ -59,7 +59,7 @@ Underground::Underground(QWidget *parent) : QWidget(parent), ui(new Ui::Undergro
                                  { tr("Vital Spirit"), toInt(Lead::VitalSpirit) } });
     ui->comboMenuLead->addMenu(tr("Synchronize"), Translator::getNatures());
 
-    ui->filter->disableControls(Controls::EncounterSlots);
+    ui->filter->disableControls(Controls::EncounterSlots | Controls::Level);
 
     ui->comboBoxLocation->enableAutoComplete();
 
@@ -159,10 +159,11 @@ void Underground::generate()
 
     std::vector<u16> species = ui->checkListPokemon->getCheckedData();
 
-    UndergroundStateFilter filter(ui->filter->getGender(), ui->filter->getAbility(), ui->filter->getShiny(), ui->filter->getHeightMin(),
-                                  ui->filter->getHeightMax(), ui->filter->getWeightMin(), ui->filter->getWeightMax(),
-                                  ui->filter->getDisableFilters(), ui->filter->getMinIVs(), ui->filter->getMaxIVs(),
-                                  ui->filter->getNatures(), ui->filter->getHiddenPowers(), species);
+    UndergroundStateFilter filter(ui->filter->getGender(), ui->filter->getAbility(), ui->filter->getShiny(), ui->filter->getLevelMin(),
+                                  ui->filter->getLevelMax(), ui->filter->getHeightMin(), ui->filter->getHeightMax(),
+                                  ui->filter->getWeightMin(), ui->filter->getWeightMax(), ui->filter->getDisableFilters(),
+                                  ui->filter->getMinIVs(), ui->filter->getMaxIVs(), ui->filter->getNatures(), ui->filter->getHiddenPowers(),
+                                  species);
     UndergroundGenerator generator(initialAdvances, maxAdvances, offset, lead, bonus, levelFlag,
                                    encounters[ui->comboBoxLocation->currentIndex()], *currentProfile, filter);
 

--- a/Form/Gen8/Wild8.cpp
+++ b/Form/Gen8/Wild8.cpp
@@ -168,6 +168,7 @@ void Wild8::encounterIndexChanged(int index)
     if (index >= 0)
     {
         auto encounter = ui->comboBoxEncounter->getEnum<Encounter>();
+        u16 currentLocation = ui->comboBoxLocation->getCurrentUShort();
 
         bool honey = encounter == Encounter::HoneyTree;
 
@@ -190,7 +191,8 @@ void Wild8::encounterIndexChanged(int index)
         std::ranges::transform(encounters, std::back_inserter(locs), [](const EncounterArea8 &area) { return area.getLocation(); });
 
         ui->comboBoxLocation->clear();
-        ui->comboBoxLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()));
+        ui->comboBoxLocation->addItems(Translator::getLocations(locs, currentProfile->getVersion()), locs);
+        ui->comboBoxLocation->setCurrentIndexByData(currentLocation);
     }
 }
 
@@ -330,12 +332,18 @@ void Wild8::pokemonIndexChanged(int index)
     if (index <= 0)
     {
         ui->filter->resetEncounterSlots();
+        ui->spinBoxLevelMin->setValue(0);
+        ui->spinBoxLevelMax->setValue(0);
     }
     else
     {
         u16 num = ui->comboBoxPokemon->getCurrentUShort();
         auto flags = encounters[ui->comboBoxLocation->currentIndex()].getSlots(num);
         ui->filter->toggleEncounterSlots(flags);
+
+        auto range = encounters[ui->comboBoxLocation->currentIndex()].getLevelRange(num);
+        ui->spinBoxLevelMin->setValue(range.first);
+        ui->spinBoxLevelMax->setValue(range.second);
     }
 }
 

--- a/Form/Gen8/Wild8.cpp
+++ b/Form/Gen8/Wild8.cpp
@@ -213,7 +213,7 @@ void Wild8::generate()
         return;
     }
 
-    if (!ui->filter->isValid())
+    if (!ui->filter->isValid(ui->spinBoxLevelMin->value(), ui->spinBoxLevelMax->value()))
     {
         return;
     }
@@ -334,6 +334,7 @@ void Wild8::pokemonIndexChanged(int index)
         ui->filter->resetEncounterSlots();
         ui->spinBoxLevelMin->setValue(0);
         ui->spinBoxLevelMax->setValue(0);
+        ui->filter->setLevelRange(1, 100);
     }
     else
     {
@@ -344,6 +345,7 @@ void Wild8::pokemonIndexChanged(int index)
         auto range = encounters[ui->comboBoxLocation->currentIndex()].getLevelRange(num);
         ui->spinBoxLevelMin->setValue(range.first);
         ui->spinBoxLevelMax->setValue(range.second);
+        ui->filter->setLevelRange(range.first, range.second);
     }
 }
 

--- a/Form/Gen8/Wild8.ui
+++ b/Form/Gen8/Wild8.ui
@@ -323,6 +323,34 @@
       <item row="7" column="2">
        <widget class="ComboBox" name="comboBoxReplacement1"/>
       </item>
+      <item row="8" column="0" colspan="3">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="labelLevel">
+        <property name="text">
+         <string>Levels</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="spinBoxLevelMin">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2">
+       <widget class="QSpinBox" name="spinBoxLevelMax">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -381,6 +409,8 @@
   <tabstop>checkBoxReplacement</tabstop>
   <tabstop>comboBoxReplacement0</tabstop>
   <tabstop>comboBoxReplacement1</tabstop>
+  <tabstop>spinBoxLevelMin</tabstop>
+  <tabstop>spinBoxLevelMax</tabstop>
   <tabstop>tableView</tabstop>
  </tabstops>
  <resources/>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -3472,7 +3472,7 @@
     <name>HiddenGrotto</name>
     <message>
         <source>Level Range</source>
-        <translation type="unfinished"></translation>
+        <translation>Levelspanne</translation>
     </message>
     <message>
         <source>Min</source>
@@ -3488,7 +3488,7 @@
     </message>
     <message>
         <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
+        <translation>Level außerhalb der Levelspanne!</translation>
     </message>
     <message>
         <source>Hidden Grotto</source>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation>Versteckte Lichtungen</translation>
     </message>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -1171,12 +1171,12 @@
     <message>
         <location filename="../Controls/EggSettings.cpp" line="77"/>
         <source>Copy IVs to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>IVs in die Zwischenablage kopieren</translation>
     </message>
     <message>
         <location filename="../Controls/EggSettings.cpp" line="78"/>
         <source>Paste IVs from clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>IVs aus der Zwischenablage einfügen</translation>
     </message>
     <message>
         <location filename="../Controls/EggSettings.cpp" line="274"/>
@@ -1223,12 +1223,12 @@
     <message>
         <location filename="../Controls/EggSettings.cpp" line="324"/>
         <source>Invalid Format</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültiges Format</translation>
     </message>
     <message>
         <location filename="../Controls/EggSettings.cpp" line="324"/>
         <source>The clipboard text did not match the expected format.</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Text in der Zwischenablage hat ein ungültiges Format</translation>
     </message>
     <message>
         <location filename="../Controls/EggSettings.cpp" line="69"/>
@@ -1267,7 +1267,7 @@
     </message>
     <message>
         <source>Redraws</source>
-        <translation type="unfinished">Aufnahme Advances</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calibration</source>
@@ -2812,12 +2812,12 @@
     <message>
         <location filename="../Controls/Filter.cpp" line="102"/>
         <source>Copy IVs to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>IVs in die Zwischenablage kopieren</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="103"/>
         <source>Paste IVs from clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>IVs aus der Zwischenablage einfügen</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
@@ -2830,17 +2830,17 @@
         <location filename="../Controls/Filter.cpp" line="400"/>
         <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültige Filter Einstellungen</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="393"/>
         <source>Level minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>Level Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>Größen Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="424"/>
@@ -2850,37 +2850,37 @@
     <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>KP Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>Angr Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>Vert Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>SpAng Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>SpVer Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>Init Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
-        <translation type="unfinished"></translation>
+        <translation>KP Mininum ist Größer als Maximum</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="424"/>
@@ -2890,12 +2890,12 @@
     <message>
         <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültiges Format</translation>
     </message>
     <message>
         <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Text in der Zwischenablage hat ein ungültiges Format</translation>
     </message>
     <message>
         <source>HP</source>
@@ -3269,11 +3269,11 @@
     </message>
     <message>
         <source>Seth</source>
-        <translation></translation>
+        <translation>Duncan</translation>
     </message>
     <message>
         <source>Thomas</source>
-        <translation type="unfinished"></translation>
+        <translation>Wolf</translation>
     </message>
     <message>
         <source>Party Lead</source>
@@ -5941,7 +5941,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplizieren</translation>
     </message>
 </context>
 <context>
@@ -5992,7 +5992,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplizieren</translation>
     </message>
 </context>
 <context>
@@ -6043,7 +6043,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplizieren</translation>
     </message>
 </context>
 <context>
@@ -6094,7 +6094,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplizieren</translation>
     </message>
 </context>
 <context>
@@ -8833,12 +8833,12 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     <message>
         <location filename="../Controls/TabWidget.cpp" line="27"/>
         <source>Transfer Filters</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter übertragen</translation>
     </message>
     <message>
         <location filename="../Controls/TabWidget.cpp" line="30"/>
         <source>Transfer Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Einstellungen übertragen</translation>
     </message>
 </context>
 <context>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -1805,7 +1805,7 @@
     <message>
         <location filename="../Util/EncounterLookup.cpp" line="49"/>
         <source>Level Range</source>
-        <translation>Levelbereich</translation>
+        <translation>Levelspanne</translation>
     </message>
     <message>
         <source>Ruby</source>
@@ -2920,6 +2920,10 @@
     <message>
         <source>Weight</source>
         <translation>Gewicht</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>Zurücksetzen</translation>
     </message>
 </context>
 <context>
@@ -9146,6 +9150,26 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation>Levelspanne</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation>Unültiges level</translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation>Level außerhalb der Levelspanne!</translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>Generation 3 Wild</translation>
     </message>
@@ -9357,6 +9381,26 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation>Levelspanne</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation>Unültiges level</translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation>Level außerhalb der Levelspanne!</translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generation 4 Wild</translation>
@@ -9787,6 +9831,26 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation>Levelspanne</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation>Unültiges level</translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation>Level außerhalb der Levelspanne!</translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Generation 5 Wild</translation>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -2843,6 +2843,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation>Level filter außerhalb der Levelspanne</translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2878,12 +2883,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation>Ungültiges level</translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation>Ungültiges level</translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation>Level filter außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation>Levelspanne</translation>
@@ -9186,14 +9188,6 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation>Ungültiges level</translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation>Level filter außerhalb der Levelspanne!</translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation>Generation 3 Wild</translation>
     </message>
@@ -9214,67 +9208,67 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
         <translation>Nicht vorhanden</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♂ Lead</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♀ Lead</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
         <source>Slot Modifier</source>
         <translation>Slot Modifizierer</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Magnet Pull</source>
         <translation>Magnetfalle</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Static</source>
         <translation>Statik</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="74"/>
-        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <location filename="../Gen3/Wild3.cpp" line="75"/>
+        <location filename="../Gen3/Wild3.cpp" line="86"/>
         <source>Level Modifier</source>
         <translation>Level Modifizierer</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="75"/>
-        <location filename="../Gen3/Wild3.cpp" line="86"/>
+        <location filename="../Gen3/Wild3.cpp" line="76"/>
+        <location filename="../Gen3/Wild3.cpp" line="87"/>
         <source>Hustle</source>
         <translation>Übereifer</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="76"/>
-        <location filename="../Gen3/Wild3.cpp" line="87"/>
+        <location filename="../Gen3/Wild3.cpp" line="77"/>
+        <location filename="../Gen3/Wild3.cpp" line="88"/>
         <source>Pressure</source>
         <translation>Erzwinger</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="77"/>
-        <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation>Munterkeit</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation>Generiere Zeiten für Seed</translation>
     </message>
@@ -9335,8 +9329,8 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Superangel</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation>Synchro</translation>
     </message>
@@ -9361,8 +9355,8 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Sucher</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation>Charmebolzen</translation>
     </message>
@@ -9409,14 +9403,6 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation>Ungültiges level</translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation>Level filter außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generation 4 Wild</translation>
@@ -9851,14 +9837,6 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation>Ungültiges level</translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation>Level filter außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Generation 5 Wild</translation>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation>Nicht vorhanden</translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation>Seed (Halten / Aufnahme)</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation>Inkompatible Eltern</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Geschlechter der ausgewählten Eltern sind zum Züchten nicht kompatibel</translation>
     </message>
@@ -1433,49 +1433,49 @@
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation>Poketch berechnen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation>Generiere Zeiten für Seed</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation>Nicht zur Freundschaftsstatus-App wechseln</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation>1 mal zur Freundschaftsstatus-App wechseln, aber nicht antippen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation>Freundschaftsstatus-App Doppeltipps</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation>Münzwurf-App tipps</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation>Poketch tipps</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation>Inkompatible Eltern</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Geschlechter der ausgewählten Eltern sind zum Züchten nicht kompatibel</translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation>Inkompatible Eltern</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Geschlechter der ausgewählten Eltern sind zum Züchten nicht kompatibel</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation>Eltern neu angeordnet</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation>Eltern wurden passend zum Spiel ausgetauscht</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation>Ungültige Datumsspanne</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation>Startdatum ist nach Enddatum</translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation>Ungültiges Format</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation>Wunderkarte hat nicht die korrekte Größe</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation>Dateifehler</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation>Es gab ein Problem beim öffnen der Wunderkarte</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation>Ungültige Datumsspanne</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation>Startdatum ist nach Enddatum</translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2922,8 +2928,8 @@
         <translation>Gewicht</translation>
     </message>
     <message>
-        <source>Reset</source>
-        <translation>Zurücksetzen</translation>
+        <source>Level</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3483,14 +3489,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation>Level außerhalb der Levelspanne!</translation>
-    </message>
-    <message>
         <source>Hidden Grotto</source>
         <translation>Versteckte Lichtungen</translation>
     </message>
@@ -3639,46 +3637,46 @@
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation>Ungültige Datumsspanne</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation>Startdatum ist nach Enddatum</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation>Einstellungen sind für schnelle IV/SHA Suche konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Einstellungen sind für schnelle IV Suche konfiguriert.
 Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Profil hat keine IV cache Datei Konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Schnellsuche ist aufgrund der IV Advances oder IV Filter deaktiviert</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Lasse Minimale/Maximale IV Advances unter %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Setze IV Filter auf häufig verwendete IV spreads</translation>
     </message>
@@ -7445,7 +7443,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation>Generiere Zeiten für Seed</translation>
     </message>
@@ -7565,26 +7563,26 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Sucher</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <location filename="../Gen4/Static4.cpp" line="68"/>
+        <location filename="../Gen4/Static4.cpp" line="73"/>
         <source>Cute Charm</source>
         <translation>Charmebolzen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
         <source>None</source>
         <translation>Nicht vorhanden</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation></translation>
     </message>
@@ -7613,13 +7611,13 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation>Generiere Zeiten für Seed</translation>
     </message>
@@ -7879,74 +7877,74 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation>Nicht vorhanden</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
         <translation>Charmebolzen</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♂ Lead</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♀ Lead</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../Gen5/Static5.cpp" line="73"/>
         <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♀ Lead</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation>Ungültige Datumsspanne</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation>Startdatum ist nach Enddatum</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation>Einstellungen sind für schnelle IV/SHA Suche konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Einstellungen sind für schnelle IV Suche konfiguriert.
 Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Profil hat keine IV cache Datei Konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Schnellsuche ist aufgrund der IV Advances oder IV Filter deaktiviert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Lasse Minimale/Maximale IV Advances unter %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Setze IV Filter auf häufig verwendete IV spreads</translation>
     </message>
@@ -9045,12 +9043,12 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation>Fehlende Seeds</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation>Bitte fehlende Seed Informationen eingeben</translation>
     </message>
@@ -9077,32 +9075,32 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation>Ei-Attacken</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation>Spezies</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation></translation>
     </message>
@@ -9117,22 +9115,22 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Schillernd</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation>Wesen</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation>Fähigkeit</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation>KP</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation>Angr</translation>
     </message>
@@ -9157,38 +9155,28 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Init</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation>Geschlecht</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
         <translation>Persönlichkeit</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished">Größe</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
+        <translation type="unfinished">Gewicht</translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation>Levelspanne</translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation>Unültiges level</translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation>Level außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation>Generation 3 Wild</translation>
@@ -9398,29 +9386,13 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <source>Offset</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation>Levelspanne</translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation>Unültiges level</translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation>Level außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generation 4 Wild</translation>
@@ -9625,23 +9597,23 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation>Bitte nur einen einzigen Encounter Slot für Pokéradar RNG auswählen</translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation>Bitte nur einen einzigen Encounter Slot für Honigbaum RNG auswählen</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation>Fehlender perfekter IV</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation>Diese Suche benötigt mindestens einen IV Wert auf 31</translation>
     </message>
@@ -9679,18 +9651,18 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation>Zu viele Slots ausgewählt</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
@@ -9848,29 +9820,13 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <source>Honey Tree</source>
         <translation>Honigbaum</translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation>Levelspanne</translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation>Unültiges level</translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation>Level außerhalb der Levelspanne!</translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Generation 5 Wild</translation>
@@ -10142,46 +10098,50 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation>Ungültige Datumsspanne</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation>Startdatum ist nach Enddatum</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation>Einstellungen sind für schnelle IV/SHA Suche konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Einstellungen sind für schnelle IV Suche konfiguriert.
 Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Profil hat keine IV cache Datei Konfiguriert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Schnellsuche ist aufgrund der IV Advances oder IV Filter deaktiviert</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Lasse Minimale/Maximale IV Advances unter %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Setze IV Filter auf häufig verwendete IV spreads</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10346,22 +10306,22 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Synchro</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation>Fehlende Seeds</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation>Bitte fehlende Seed Informationen eingeben</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation>Zu viele Slots ausgewählt</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation>Bitte nur einen einzigen Encounter Slot für Honigbaum RNG auswählen</translation>
     </message>
@@ -10431,6 +10391,10 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     <message>
         <source>Feebas Tile</source>
         <translation>Barschwa Kachel</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation>Ungültiges level</translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation>Level filter außerhalb der Levelspanne!</translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation>Levelspanne</translation>
     </message>
@@ -9167,16 +9175,24 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     <message>
         <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Height</source>
-        <translation type="unfinished">Größe</translation>
+        <translation>Größe</translation>
     </message>
     <message>
         <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Weight</source>
-        <translation type="unfinished">Gewicht</translation>
+        <translation>Gewicht</translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
+    <message>
+        <source>Invalid level</source>
+        <translation>Ungültiges level</translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation>Level filter außerhalb der Levelspanne!</translation>
+    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation>Generation 3 Wild</translation>
@@ -9388,11 +9404,19 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Levels</source>
-        <translation type="unfinished"></translation>
+        <translation>Level</translation>
     </message>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation>Ungültiges level</translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation>Level filter außerhalb der Levelspanne!</translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generation 4 Wild</translation>
@@ -9822,11 +9846,19 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Levels</source>
-        <translation type="unfinished"></translation>
+        <translation>Level</translation>
     </message>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation>Ungültiges level</translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation>Level filter außerhalb der Levelspanne!</translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Generation 5 Wild</translation>
@@ -10141,7 +10173,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Levels</source>
-        <translation type="unfinished"></translation>
+        <translation>Level</translation>
     </message>
 </context>
 <context>
@@ -10394,7 +10426,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <source>Levels</source>
-        <translation type="unfinished"></translation>
+        <translation>Level</translation>
     </message>
 </context>
 <context>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -3472,6 +3472,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -3478,6 +3478,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished">Rango de niveles</translation>
     </message>
@@ -9183,6 +9191,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>Generación 3 salvaje</translation>
     </message>
@@ -9398,6 +9414,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generación 4 salvaje</translation>
@@ -9832,6 +9856,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -2844,6 +2844,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2879,12 +2884,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3477,14 +3487,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished">Rango de niveles</translation>
@@ -9191,14 +9193,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation>Generación 3 salvaje</translation>
     </message>
@@ -9219,67 +9213,67 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Filtros</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♂ Lead</source>
         <translation>♂ Lidera</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♀ Lead</source>
         <translation>♀ Lidera</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
         <source>Slot Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Magnet Pull</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Static</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="74"/>
-        <location filename="../Gen3/Wild3.cpp" line="85"/>
-        <source>Level Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="75"/>
         <location filename="../Gen3/Wild3.cpp" line="86"/>
-        <source>Hustle</source>
+        <source>Level Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="76"/>
         <location filename="../Gen3/Wild3.cpp" line="87"/>
-        <source>Pressure</source>
+        <source>Hustle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="77"/>
         <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <source>Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation>Generar tiempos para las seed</translation>
     </message>
@@ -9340,8 +9334,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Supercaña</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation>Sincronía</translation>
     </message>
@@ -9366,8 +9360,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Buscador</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation>Gran encanto</translation>
     </message>
@@ -9414,14 +9408,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generación 4 salvaje</translation>
@@ -9856,14 +9842,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
@@ -1339,14 +1339,14 @@
         <translation>Seed (Mantener / Recoger)</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1434,49 +1434,49 @@
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation>Generar tiempo para las seed</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1612,36 +1612,36 @@
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2212,36 +2212,36 @@
         <translation>Nivel</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2821,64 +2821,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2923,8 +2929,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <source>Level</source>
+        <translation type="unfinished">Nivel</translation>
     </message>
 </context>
 <context>
@@ -3473,7 +3479,7 @@
     <name>HiddenGrotto</name>
     <message>
         <source>Level Range</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Rango de niveles</translation>
     </message>
     <message>
         <source>Min</source>
@@ -3481,14 +3487,6 @@
     </message>
     <message>
         <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3640,45 +3638,45 @@
         <translation type="unfinished">Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7451,7 +7449,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7571,26 +7569,26 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Buscador</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
         <translation>Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <location filename="../Gen4/Static4.cpp" line="68"/>
+        <location filename="../Gen4/Static4.cpp" line="73"/>
         <source>Cute Charm</source>
         <translation>Gran encanto</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation type="unfinished">♀ Lidera</translation>
     </message>
@@ -7619,13 +7617,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation>♂ Lidera</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7885,73 +7883,73 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
         <translation type="unfinished">Gran encanto</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♂ Lead</source>
         <translation type="unfinished">♂ Lidera</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♀ Lead</source>
         <translation type="unfinished">♀ Lidera</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="73"/>
-        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation type="unfinished">Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9050,12 +9048,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9082,32 +9080,32 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation type="unfinished">Nivel</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9122,22 +9120,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation type="unfinished">Naturaleza</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation type="unfinished">Habilidad</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation type="unfinished">PS</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation type="unfinished">Ataque</translation>
     </message>
@@ -9162,38 +9160,28 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Velocidad</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation type="unfinished">Género</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
         <translation type="unfinished">Característica</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation>Generación 3 salvaje</translation>
@@ -9403,29 +9391,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generación 4 salvaje</translation>
@@ -9630,23 +9602,23 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9684,18 +9656,18 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation>No</translation>
     </message>
@@ -9853,29 +9825,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>
@@ -10147,44 +10103,48 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10350,22 +10310,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Sincronía</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10434,6 +10394,10 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <source>Feebas Tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -2922,6 +2922,10 @@
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9151,6 +9155,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>Generación 3 salvaje</translation>
     </message>
@@ -9362,6 +9386,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Generación 4 salvaje</translation>
@@ -9792,6 +9836,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9176,6 +9184,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9391,6 +9407,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9825,6 +9849,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -2921,6 +2921,10 @@
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9144,6 +9148,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9355,6 +9379,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9785,6 +9829,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -2843,6 +2843,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2878,12 +2883,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
@@ -9184,14 +9186,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9212,67 +9206,67 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Filtres</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♀ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
-        <source>Slot Modifier</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Magnet Pull</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="74"/>
         <location filename="../Gen3/Wild3.cpp" line="85"/>
-        <source>Level Modifier</source>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <source>Slot Modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Magnet Pull</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="75"/>
         <location filename="../Gen3/Wild3.cpp" line="86"/>
-        <source>Hustle</source>
+        <source>Level Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="76"/>
         <location filename="../Gen3/Wild3.cpp" line="87"/>
-        <source>Pressure</source>
+        <source>Hustle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="77"/>
         <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <source>Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9333,8 +9327,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9359,8 +9353,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9407,14 +9401,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9849,14 +9835,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1433,49 +1433,49 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2922,7 +2928,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset</source>
+        <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3483,14 +3489,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3639,45 +3637,45 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7444,7 +7442,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7564,26 +7562,26 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
-        <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Static4.cpp" line="68"/>
         <location filename="../Gen4/Static4.cpp" line="73"/>
+        <source>Cute Charm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,13 +7610,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7878,73 +7876,73 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen5/Static5.cpp" line="73"/>
         <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9041,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9075,32 +9073,32 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9115,22 +9113,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation type="unfinished">Nature</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation type="unfinished">Talent</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation type="unfinished">PV</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation type="unfinished">Attaque</translation>
     </message>
@@ -9155,38 +9153,28 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation type="unfinished">Genre</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
@@ -9396,29 +9384,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9623,23 +9595,23 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9677,18 +9649,18 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9846,29 +9818,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>
@@ -10140,44 +10096,48 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10343,22 +10303,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10427,6 +10387,10 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <source>Feebas Tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation>Seed (Allevamento / Ritiro)</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation>Genitori Incompatibili</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Il sesso dei genitori selezionati non è compatibile per l&apos;accoppiamento</translation>
     </message>
@@ -1429,49 +1429,49 @@
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation>Calcola PokeKron</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation>Genera tempi per il seed</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation>Non entrare mai nell&apos;applicazione della felicità</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation>Entra nell&apos;applicazione della felicità una volta ma non cliccare</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation>Doppi tocchi nell&apos;applicazione della felicità: %1</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation>Tocchi nell&apos;applicazione del lancio della moneta: %1</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation>Tocchi nel PokeKron</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation>Genitori Incompatibili</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Il sesso dei genitori selezionati non è compatibile per l&apos;accoppiamento</translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation>Genitori Incompatibili</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>Il sesso dei genitori selezionati non è compatibile per l&apos;accoppiamento</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation>Genitori Riordinati</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation>I genitori sono stati invertiti per fare corrispondenza con il gioco</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation>Intervallo di date non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation>La data iniziale è successiva alla data finale</translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation>Livello</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation>Formato non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation>La la dimensione della Scheda Segreta non è corretta</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation>Errore file</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation>Si è verificato un problema durante l&apos;apertura della Scheda Segreta</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation>Intervallo di date non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation>La data iniziale è successiva alla data finale</translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation>Incolla le IVs dagli appunti</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation>Impostazioni del filtro non valide</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation>L&apos;altezza minima è maggiore della massima</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation>I PS minimi sono maggiori dei massimi</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation>L&apos;Att minimo è maggiore del massimo</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation>La Dif minima è maggiore della massima</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation>L&apos;AttSp minimo è maggiore del massimo</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation>La DifSp minima è maggiore della massima</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation>La Vel minima è maggiore della massima</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation>Il peso minimo è maggiore del massimo</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation>Formato non valido</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation>Il testo negli appunti non corrisponde al formato previsto.</translation>
     </message>
@@ -2922,8 +2928,8 @@
         <translation>Peso</translation>
     </message>
     <message>
-        <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <source>Level</source>
+        <translation type="unfinished">Livello</translation>
     </message>
 </context>
 <context>
@@ -3472,23 +3478,15 @@
     <name>HiddenGrotto</name>
     <message>
         <source>Level Range</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Intervallo Livello</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Minimo</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Massimo</translation>
     </message>
     <message>
         <source>Hidden Grotto</source>
@@ -3639,46 +3637,46 @@
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation>Intervallo di date non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation>La data iniziale è successiva alla data finale</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished">Le impostazioni sono configurate per la ricerca rapida IV/SHA</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Le impostazioni sono configurate per la ricerca rapida IV.
 Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Il profilo non ha un file IV cache configurato</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Le impostazioni non sono configurate per la ricerca rapida</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Mantieni gli avanzamenti iniziali/massimi sotto %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Assicurati che i filtri IV siano impostati per spread comuni</translation>
     </message>
@@ -7445,7 +7443,7 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation>Genera tempi per il seed</translation>
     </message>
@@ -7565,26 +7563,26 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Ricercatore</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <location filename="../Gen4/Static4.cpp" line="68"/>
+        <location filename="../Gen4/Static4.cpp" line="73"/>
         <source>Cute Charm</source>
         <translation>Incantevole</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation>Leader ♀</translation>
     </message>
@@ -7613,13 +7611,13 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation>Leader ♂</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation>Genera tempi per il seed</translation>
     </message>
@@ -7879,74 +7877,74 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
         <translation>Incantevole</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♂ Lead</source>
         <translation>Leader ♂</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♀ Lead</source>
         <translation>Leader ♀</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="73"/>
-        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation>Intervallo di date non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation>La data iniziale è successiva alla data finale</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation>Le impostazioni sono configurate per la ricerca rapida IV/SHA</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Le impostazioni sono configurate per la ricerca rapida IV.
 Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Il profilo non ha un file IV cache configurato</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Le impostazioni non sono configurate per la ricerca rapida</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Mantieni gli avanzamenti iniziali/massimi sotto %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Assicurati che i filtri IV siano impostati per spread comuni</translation>
     </message>
@@ -9045,12 +9043,12 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation>Seed mancanti</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation>Per favore inserisci le informazioni mancanti del seed</translation>
     </message>
@@ -9077,32 +9075,32 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation>Avanzamenti</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation>Mossa Uovo</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation>Strumento</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation>Specie</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation>Livello</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9117,22 +9115,22 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Cromatico</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation>Natura</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation>Abilità</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation>Att</translation>
     </message>
@@ -9157,38 +9155,28 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Vel</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation>Sesso</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
         <translation>Caratteristica</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished">Altezza</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
+        <translation type="unfinished">Peso</translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation>Selvatici Gen 3</translation>
@@ -9398,29 +9386,13 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Selvatici Gen 4</translation>
@@ -9625,23 +9597,23 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation>Per favore seleziona un unico slot incotro per il Poke Radar</translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation>Per favore seleziona un unico slot incontro per l&apos;Albero del Miele</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation>IV Perfette Mancanti</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation>Questa ricerca necessita di almeno una IV a 31</translation>
     </message>
@@ -9679,18 +9651,18 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation>Troppi slot selezionati</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9848,29 +9820,13 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <source>Honey Tree</source>
         <translation>Albero del Miele</translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Selvatici Gen 5</translation>
@@ -10142,46 +10098,50 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation>Intervallo di date non valido</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation>La data iniziale è successiva alla data finale</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation>Le impostazioni sono configurate per la ricerca rapida IV/SHA</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation>Le impostazioni sono configurate per la ricerca rapida IV.
 Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation>Il profilo non ha un file IV cache configurato</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation>Le impostazioni non sono configurate per la ricerca rapida</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation>Mantieni gli avanzamenti iniziali/massimi sotto %1/%2</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation>Assicurati che i filtri IV siano impostati per spread comuni</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10346,22 +10306,22 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Sincronismo</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation>Seed mancanti</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation>Per favore inserisci le informazioni mancanti del seed</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation>Troppi slot selezionati</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation>Per favore seleziona un unico slot di incontro per l&apos;Albero del Miele</translation>
     </message>
@@ -10431,6 +10391,10 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     <message>
         <source>Feebas Tile</source>
         <translation>Casella Feebas</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -2921,6 +2921,10 @@
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9146,6 +9150,26 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>Selvatici Gen 3</translation>
     </message>
@@ -9357,6 +9381,26 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Selvatici Gen 4</translation>
@@ -9787,6 +9831,26 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Selvatici Gen 5</translation>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation>Meandri Nascosti</translation>
     </message>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished">Intervallo Livello</translation>
     </message>
@@ -9178,6 +9186,14 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>Selvatici Gen 3</translation>
     </message>
@@ -9393,6 +9409,14 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Selvatici Gen 4</translation>
@@ -9827,6 +9851,14 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Selvatici Gen 5</translation>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -2843,6 +2843,11 @@
         <translation>L&apos;altezza minima è maggiore della massima</translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation>I PS minimi sono maggiori dei massimi</translation>
@@ -2878,12 +2883,17 @@
         <translation>Il peso minimo è maggiore del massimo</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation>Formato non valido</translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation>Il testo negli appunti non corrisponde al formato previsto.</translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished">Intervallo Livello</translation>
@@ -9186,14 +9188,6 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation>Selvatici Gen 3</translation>
     </message>
@@ -9214,67 +9208,67 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Filtri</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
         <translation>Nessuna</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♂ Lead</source>
         <translation>Leader ♂</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♀ Lead</source>
         <translation>Leader ♀</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
         <source>Slot Modifier</source>
         <translation>Modificatore Slot</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Magnet Pull</source>
         <translation>Magnetismo</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Static</source>
         <translation>Statico</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="74"/>
-        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <location filename="../Gen3/Wild3.cpp" line="75"/>
+        <location filename="../Gen3/Wild3.cpp" line="86"/>
         <source>Level Modifier</source>
         <translation>Modificatore Livello</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="75"/>
-        <location filename="../Gen3/Wild3.cpp" line="86"/>
+        <location filename="../Gen3/Wild3.cpp" line="76"/>
+        <location filename="../Gen3/Wild3.cpp" line="87"/>
         <source>Hustle</source>
         <translation>Tuttafretta</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="76"/>
-        <location filename="../Gen3/Wild3.cpp" line="87"/>
+        <location filename="../Gen3/Wild3.cpp" line="77"/>
+        <location filename="../Gen3/Wild3.cpp" line="88"/>
         <source>Pressure</source>
         <translation>Pressione</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="77"/>
-        <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation>Spiritovivo</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation>Genera tempi per il seed</translation>
     </message>
@@ -9335,8 +9329,8 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Super Amo</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation>Sincronismo</translation>
     </message>
@@ -9361,8 +9355,8 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Ricercatore</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation>Incantevole</translation>
     </message>
@@ -9409,14 +9403,6 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>Selvatici Gen 4</translation>
@@ -9851,14 +9837,6 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>Selvatici Gen 5</translation>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9176,6 +9184,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9391,6 +9407,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9825,6 +9849,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -2921,6 +2921,10 @@
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9144,6 +9148,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9355,6 +9379,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9785,6 +9829,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1433,49 +1433,49 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2922,7 +2928,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset</source>
+        <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3483,14 +3489,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3639,45 +3637,45 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7444,7 +7442,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7564,26 +7562,26 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
-        <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Static4.cpp" line="68"/>
         <location filename="../Gen4/Static4.cpp" line="73"/>
+        <source>Cute Charm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,13 +7610,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7878,73 +7876,73 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen5/Static5.cpp" line="73"/>
         <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9041,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9075,32 +9073,32 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9115,22 +9113,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9155,38 +9153,28 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
@@ -9396,29 +9384,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9623,23 +9595,23 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9677,18 +9649,18 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9846,29 +9818,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>
@@ -10140,44 +10096,48 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10343,22 +10303,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10427,6 +10387,10 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <source>Feebas Tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -2843,6 +2843,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2878,12 +2883,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
@@ -9184,14 +9186,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9212,67 +9206,67 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♀ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
-        <source>Slot Modifier</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Magnet Pull</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="74"/>
         <location filename="../Gen3/Wild3.cpp" line="85"/>
-        <source>Level Modifier</source>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <source>Slot Modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Magnet Pull</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="75"/>
         <location filename="../Gen3/Wild3.cpp" line="86"/>
-        <source>Hustle</source>
+        <source>Level Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="76"/>
         <location filename="../Gen3/Wild3.cpp" line="87"/>
-        <source>Pressure</source>
+        <source>Hustle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="77"/>
         <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <source>Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9333,8 +9327,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9359,8 +9353,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9407,14 +9401,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9849,14 +9835,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9176,6 +9184,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9391,6 +9407,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9825,6 +9849,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -2921,6 +2921,10 @@
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9144,6 +9148,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9355,6 +9379,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9785,6 +9829,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1433,49 +1433,49 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2922,7 +2928,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset</source>
+        <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3483,14 +3489,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3639,45 +3637,45 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7444,7 +7442,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7564,26 +7562,26 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
-        <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Static4.cpp" line="68"/>
         <location filename="../Gen4/Static4.cpp" line="73"/>
+        <source>Cute Charm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7612,13 +7610,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7878,73 +7876,73 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
-        <source>♀ Lead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen5/Static5.cpp" line="73"/>
         <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9041,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9075,32 +9073,32 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9115,22 +9113,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9155,38 +9153,28 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
@@ -9396,29 +9384,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9623,23 +9595,23 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9677,18 +9649,18 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9846,29 +9818,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>
@@ -10140,44 +10096,48 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10343,22 +10303,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10427,6 +10387,10 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <source>Feebas Tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -2843,6 +2843,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2878,12 +2883,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished"></translation>
@@ -9184,14 +9186,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9212,67 +9206,67 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♂ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
-        <source>♀ Lead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
-        <source>Slot Modifier</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Magnet Pull</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
-        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="74"/>
         <location filename="../Gen3/Wild3.cpp" line="85"/>
-        <source>Level Modifier</source>
+        <source>♂ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <source>♀ Lead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <source>Slot Modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Magnet Pull</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <source>Static</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="75"/>
         <location filename="../Gen3/Wild3.cpp" line="86"/>
-        <source>Hustle</source>
+        <source>Level Modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="76"/>
         <location filename="../Gen3/Wild3.cpp" line="87"/>
-        <source>Pressure</source>
+        <source>Hustle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen3/Wild3.cpp" line="77"/>
         <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <source>Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9333,8 +9327,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9359,8 +9353,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9407,14 +9401,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation type="unfinished"></translation>
@@ -9849,14 +9835,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -93,7 +93,7 @@
 <context>
     <name>ComboBoxProxyModel</name>
     <message>
-        <location filename="../Controls/ComboBoxProxy.hpp" line="109"/>
+        <location filename="../Controls/ComboBoxProxy.hpp" line="133"/>
         <source>None</source>
         <translation>无</translation>
     </message>
@@ -1338,14 +1338,14 @@
         <translation>Seed (生成 / 领取)</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Incompatible Parents</source>
         <translation>亲代组合不兼容</translation>
     </message>
     <message>
-        <location filename="../Gen3/Eggs3.cpp" line="129"/>
-        <location filename="../Gen3/Eggs3.cpp" line="167"/>
+        <location filename="../Gen3/Eggs3.cpp" line="131"/>
+        <location filename="../Gen3/Eggs3.cpp" line="169"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>所选亲代性别组合无法进行培育孵蛋。</translation>
     </message>
@@ -1433,49 +1433,49 @@
         <translation>检索</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="73"/>
+        <location filename="../Gen4/Eggs4.cpp" line="74"/>
         <source>Calculate Poketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="78"/>
+        <location filename="../Gen4/Eggs4.cpp" line="79"/>
         <source>Generate times for seed</source>
         <translation>为Seed生成时间</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="147"/>
+        <location filename="../Gen4/Eggs4.cpp" line="148"/>
         <source>Do not switch to the happiness application at all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="157"/>
+        <location filename="../Gen4/Eggs4.cpp" line="158"/>
         <source>Switch to the happiness application once but do not click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Happiness Application Double Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="161"/>
+        <location filename="../Gen4/Eggs4.cpp" line="162"/>
         <source>Coin Flip Application Taps: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="167"/>
+        <location filename="../Gen4/Eggs4.cpp" line="168"/>
         <source>Poketch Taps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Incompatible Parents</source>
         <translation>亲代组合不兼容</translation>
     </message>
     <message>
-        <location filename="../Gen4/Eggs4.cpp" line="175"/>
-        <location filename="../Gen4/Eggs4.cpp" line="218"/>
+        <location filename="../Gen4/Eggs4.cpp" line="176"/>
+        <location filename="../Gen4/Eggs4.cpp" line="219"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>所选亲代性别组合无法进行培育孵蛋。</translation>
     </message>
@@ -1611,36 +1611,36 @@
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Incompatible Parents</source>
         <translation>亲代组合不兼容</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="138"/>
-        <location filename="../Gen5/Eggs5.cpp" line="182"/>
+        <location filename="../Gen5/Eggs5.cpp" line="139"/>
+        <location filename="../Gen5/Eggs5.cpp" line="183"/>
         <source>Gender of selected parents are not compatible for breeding</source>
         <translation>所选亲代性别组合无法进行培育孵蛋。</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parents Reordered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="145"/>
-        <location filename="../Gen5/Eggs5.cpp" line="189"/>
+        <location filename="../Gen5/Eggs5.cpp" line="146"/>
+        <location filename="../Gen5/Eggs5.cpp" line="190"/>
         <source>Parent were swapped to match the game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Invalid date range</source>
         <translation>请输入正确的日期范围</translation>
     </message>
     <message>
-        <location filename="../Gen5/Eggs5.cpp" line="175"/>
+        <location filename="../Gen5/Eggs5.cpp" line="176"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2211,36 +2211,36 @@
         <translation>等级</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Invalid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="217"/>
-        <location filename="../Gen5/Event5.cpp" line="367"/>
+        <location filename="../Gen5/Event5.cpp" line="218"/>
+        <location filename="../Gen5/Event5.cpp" line="368"/>
         <source>Wondercard is not the correct size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>File error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="267"/>
-        <location filename="../Gen5/Event5.cpp" line="417"/>
+        <location filename="../Gen5/Event5.cpp" line="268"/>
+        <location filename="../Gen5/Event5.cpp" line="418"/>
         <source>There was a problem opening the wondercard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Invalid date range</source>
         <translation>请输入正确的日期范围</translation>
     </message>
     <message>
-        <location filename="../Gen5/Event5.cpp" line="307"/>
+        <location filename="../Gen5/Event5.cpp" line="308"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2820,64 +2820,70 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
-        <location filename="../Controls/Filter.cpp" line="339"/>
-        <location filename="../Controls/Filter.cpp" line="346"/>
-        <location filename="../Controls/Filter.cpp" line="353"/>
-        <location filename="../Controls/Filter.cpp" line="360"/>
-        <location filename="../Controls/Filter.cpp" line="367"/>
-        <location filename="../Controls/Filter.cpp" line="374"/>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <location filename="../Controls/Filter.cpp" line="400"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Invalid filter settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="332"/>
+        <location filename="../Controls/Filter.cpp" line="393"/>
+        <source>Level minimum is greater than maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="400"/>
         <source>Height minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="339"/>
+        <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="346"/>
+        <location filename="../Controls/Filter.cpp" line="358"/>
         <source>Atk minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="353"/>
+        <location filename="../Controls/Filter.cpp" line="365"/>
         <source>Def minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="360"/>
+        <location filename="../Controls/Filter.cpp" line="372"/>
         <source>SpA minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="367"/>
+        <location filename="../Controls/Filter.cpp" line="379"/>
         <source>SpD minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="374"/>
+        <location filename="../Controls/Filter.cpp" line="386"/>
         <source>Spe minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="381"/>
+        <location filename="../Controls/Filter.cpp" line="407"/>
         <source>Weight minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="499"/>
+        <location filename="../Controls/Filter.cpp" line="525"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2922,8 +2928,8 @@
         <translation>体重</translation>
     </message>
     <message>
-        <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <source>Level</source>
+        <translation type="unfinished">等级</translation>
     </message>
 </context>
 <context>
@@ -3472,23 +3478,15 @@
     <name>HiddenGrotto</name>
     <message>
         <source>Level Range</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">等级范围</translation>
     </message>
     <message>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">最小</translation>
     </message>
     <message>
         <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">最大</translation>
     </message>
     <message>
         <source>Hidden Grotto</source>
@@ -3639,45 +3637,45 @@
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Invalid date range</source>
         <translation>请输入正确的日期范围</translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="337"/>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="546"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="336"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="548"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="629"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="631"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="634"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="636"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="641"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="643"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="646"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="647"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="649"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/HiddenGrotto.cpp" line="648"/>
+        <location filename="../Gen5/HiddenGrotto.cpp" line="650"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7444,7 +7442,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../Gen3/Static3.cpp" line="64"/>
+        <location filename="../Gen3/Static3.cpp" line="65"/>
         <source>Generate times for seed</source>
         <translation>为Seed生成时间</translation>
     </message>
@@ -7564,26 +7562,26 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>检索器</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="69"/>
-        <location filename="../Gen4/Static4.cpp" line="74"/>
+        <location filename="../Gen4/Static4.cpp" line="70"/>
+        <location filename="../Gen4/Static4.cpp" line="75"/>
         <source>Synchronize</source>
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="67"/>
-        <location filename="../Gen4/Static4.cpp" line="72"/>
+        <location filename="../Gen4/Static4.cpp" line="68"/>
+        <location filename="../Gen4/Static4.cpp" line="73"/>
         <source>Cute Charm</source>
         <translation>迷人身躯</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="66"/>
-        <location filename="../Gen4/Static4.cpp" line="71"/>
+        <location filename="../Gen4/Static4.cpp" line="67"/>
+        <location filename="../Gen4/Static4.cpp" line="72"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♀ Lead</source>
         <translation>♀ 队首</translation>
     </message>
@@ -7612,13 +7610,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="68"/>
-        <location filename="../Gen4/Static4.cpp" line="73"/>
+        <location filename="../Gen4/Static4.cpp" line="69"/>
+        <location filename="../Gen4/Static4.cpp" line="74"/>
         <source>♂ Lead</source>
         <translation>♂ 队首</translation>
     </message>
     <message>
-        <location filename="../Gen4/Static4.cpp" line="76"/>
+        <location filename="../Gen4/Static4.cpp" line="77"/>
         <source>Generate times for seed</source>
         <translation>为Seed生成时间</translation>
     </message>
@@ -7878,73 +7876,73 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="70"/>
-        <location filename="../Gen5/Static5.cpp" line="75"/>
+        <location filename="../Gen5/Static5.cpp" line="71"/>
+        <location filename="../Gen5/Static5.cpp" line="76"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="71"/>
-        <location filename="../Gen5/Static5.cpp" line="76"/>
+        <location filename="../Gen5/Static5.cpp" line="72"/>
+        <location filename="../Gen5/Static5.cpp" line="77"/>
         <source>Cute Charm</source>
         <translation>迷人身躯</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♂ Lead</source>
         <translation>♂ 队首</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="72"/>
-        <location filename="../Gen5/Static5.cpp" line="77"/>
+        <location filename="../Gen5/Static5.cpp" line="73"/>
+        <location filename="../Gen5/Static5.cpp" line="78"/>
         <source>♀ Lead</source>
         <translation>♀ 队首</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="73"/>
-        <location filename="../Gen5/Static5.cpp" line="78"/>
+        <location filename="../Gen5/Static5.cpp" line="74"/>
+        <location filename="../Gen5/Static5.cpp" line="79"/>
         <source>Synchronize</source>
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Invalid date range</source>
         <translation>请输入正确的日期范围</translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="358"/>
+        <location filename="../Gen5/Static5.cpp" line="359"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="466"/>
+        <location filename="../Gen5/Static5.cpp" line="467"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="471"/>
+        <location filename="../Gen5/Static5.cpp" line="472"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="478"/>
+        <location filename="../Gen5/Static5.cpp" line="479"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="483"/>
+        <location filename="../Gen5/Static5.cpp" line="484"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="484"/>
+        <location filename="../Gen5/Static5.cpp" line="485"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Static5.cpp" line="485"/>
+        <location filename="../Gen5/Static5.cpp" line="486"/>
         <source>Ensure IV filters are set to common spreads</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9041,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Missing seeds</source>
         <translation>缺失seeds</translation>
     </message>
     <message>
-        <location filename="../Gen8/Underground.cpp" line="147"/>
+        <location filename="../Gen8/Underground.cpp" line="146"/>
         <source>Please insert missing seed information</source>
         <translation>请填写缺失的seed信息</translation>
     </message>
@@ -9075,32 +9073,32 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Advances</source>
         <translation>帧数</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Egg Move</source>
         <translation>蛋招式</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Item</source>
         <translation>道具</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Species</source>
         <translation>种类</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>Level</source>
         <translation>等级</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="80"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
         <source>EC</source>
         <translation>EC</translation>
     </message>
@@ -9115,22 +9113,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>异色</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Nature</source>
         <translation>性格</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Ability</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>HP</source>
         <translation>HP</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="81"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
         <source>Atk</source>
         <translation>Atk</translation>
     </message>
@@ -9155,38 +9153,28 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>Spe</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Gender</source>
         <translation>性别</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="82"/>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
         <source>Characteristic</source>
         <translation>个性</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Height</source>
+        <translation type="unfinished">身高</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen8/UndergroundModel.hpp" line="83"/>
+        <source>Weight</source>
+        <translation type="unfinished">体重</translation>
     </message>
 </context>
 <context>
     <name>Wild3</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 3 Wild</source>
         <translation>第三世代野生乱数</translation>
@@ -9396,29 +9384,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>第四世代野生乱数</translation>
@@ -9623,23 +9595,23 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="355"/>
-        <location filename="../Gen4/Wild4.cpp" line="673"/>
+        <location filename="../Gen4/Wild4.cpp" line="680"/>
         <source>Please select a single encounter slot for Poke Radar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="371"/>
-        <location filename="../Gen4/Wild4.cpp" line="689"/>
+        <location filename="../Gen4/Wild4.cpp" line="696"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>Missing Flawless IV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="717"/>
+        <location filename="../Gen4/Wild4.cpp" line="724"/>
         <source>This search needs at least one IV at 31</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9677,18 +9649,18 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../Gen4/Wild4.cpp" line="354"/>
         <location filename="../Gen4/Wild4.cpp" line="370"/>
-        <location filename="../Gen4/Wild4.cpp" line="672"/>
-        <location filename="../Gen4/Wild4.cpp" line="688"/>
+        <location filename="../Gen4/Wild4.cpp" line="679"/>
+        <location filename="../Gen4/Wild4.cpp" line="695"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../Gen4/Wild4.cpp" line="619"/>
+        <location filename="../Gen4/Wild4.cpp" line="626"/>
         <source>No</source>
         <translation>否</translation>
     </message>
@@ -9846,29 +9818,13 @@ Profile is missing or has an incompatible SHA cache.</source>
         <source>Honey Tree</source>
         <translation>甜甜蜜树</translation>
     </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Level Range</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Min</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Max</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>第五世代野生乱数</translation>
@@ -10140,44 +10096,48 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Invalid date range</source>
         <translation>请输入正确的日期范围</translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="374"/>
+        <location filename="../Gen5/Wild5.cpp" line="381"/>
         <source>Start date is after end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="472"/>
+        <location filename="../Gen5/Wild5.cpp" line="480"/>
         <source>Settings are configured for fast IV/SHA searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="477"/>
+        <location filename="../Gen5/Wild5.cpp" line="485"/>
         <source>Settings are configured for fast IV searching.
 Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="484"/>
+        <location filename="../Gen5/Wild5.cpp" line="492"/>
         <source>Profile does not have a IV cache file configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="489"/>
+        <location filename="../Gen5/Wild5.cpp" line="497"/>
         <source>Settings are not configured for fast searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="490"/>
+        <location filename="../Gen5/Wild5.cpp" line="498"/>
         <source>Keep initial/max advances below %1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Wild5.cpp" line="491"/>
+        <location filename="../Gen5/Wild5.cpp" line="499"/>
         <source>Ensure IV filters are set to common spreads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Levels</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10343,22 +10303,22 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>同步</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Missing seeds</source>
         <translation>缺失seeds</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="210"/>
+        <location filename="../Gen8/Wild8.cpp" line="211"/>
         <source>Please insert missing seed information</source>
         <translation>请填写缺失的seed信息</translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="228"/>
+        <location filename="../Gen8/Wild8.cpp" line="229"/>
         <source>Too many slots selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen8/Wild8.cpp" line="229"/>
+        <location filename="../Gen8/Wild8.cpp" line="230"/>
         <source>Please select a single encounter slot for Honey Tree</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10428,6 +10388,10 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <source>Feebas Tile</source>
         <translation>丑丑鱼钓点</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -2921,6 +2921,10 @@
         <source>Weight</source>
         <translation>体重</translation>
     </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GameCube</name>
@@ -9144,6 +9148,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>第三世代野生乱数</translation>
     </message>
@@ -9355,6 +9379,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>第四世代野生乱数</translation>
@@ -9785,6 +9829,26 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>第五世代野生乱数</translation>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -2843,6 +2843,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Level filter outside of encounters level range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../Controls/Filter.cpp" line="351"/>
         <source>HP minimum is greater than maximum</source>
         <translation type="unfinished"></translation>
@@ -2878,12 +2883,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="424"/>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>Invalid Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Controls/Filter.cpp" line="525"/>
+        <location filename="../Controls/Filter.cpp" line="542"/>
         <source>The clipboard text did not match the expected format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3476,14 +3486,6 @@
 </context>
 <context>
     <name>HiddenGrotto</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Level Range</source>
         <translation type="unfinished">等级范围</translation>
@@ -9184,14 +9186,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gen 3 Wild</source>
         <translation>第三世代野生乱数</translation>
     </message>
@@ -9212,67 +9206,67 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>筛选项</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="71"/>
-        <location filename="../Gen3/Wild3.cpp" line="82"/>
+        <location filename="../Gen3/Wild3.cpp" line="72"/>
+        <location filename="../Gen3/Wild3.cpp" line="83"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♂ Lead</source>
         <translation>♂ 队首</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="73"/>
-        <location filename="../Gen3/Wild3.cpp" line="84"/>
+        <location filename="../Gen3/Wild3.cpp" line="74"/>
+        <location filename="../Gen3/Wild3.cpp" line="85"/>
         <source>♀ Lead</source>
         <translation>♀ 队首</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="78"/>
-        <location filename="../Gen3/Wild3.cpp" line="89"/>
+        <location filename="../Gen3/Wild3.cpp" line="79"/>
+        <location filename="../Gen3/Wild3.cpp" line="90"/>
         <source>Slot Modifier</source>
         <translation>遭遇种类修正</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Magnet Pull</source>
         <translation>磁力</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="79"/>
-        <location filename="../Gen3/Wild3.cpp" line="90"/>
+        <location filename="../Gen3/Wild3.cpp" line="80"/>
+        <location filename="../Gen3/Wild3.cpp" line="91"/>
         <source>Static</source>
         <translation>静电</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="74"/>
-        <location filename="../Gen3/Wild3.cpp" line="85"/>
+        <location filename="../Gen3/Wild3.cpp" line="75"/>
+        <location filename="../Gen3/Wild3.cpp" line="86"/>
         <source>Level Modifier</source>
         <translation>遭遇等级机率修正</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="75"/>
-        <location filename="../Gen3/Wild3.cpp" line="86"/>
+        <location filename="../Gen3/Wild3.cpp" line="76"/>
+        <location filename="../Gen3/Wild3.cpp" line="87"/>
         <source>Hustle</source>
         <translation>活力</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="76"/>
-        <location filename="../Gen3/Wild3.cpp" line="87"/>
+        <location filename="../Gen3/Wild3.cpp" line="77"/>
+        <location filename="../Gen3/Wild3.cpp" line="88"/>
         <source>Pressure</source>
         <translation>压迫感</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="77"/>
-        <location filename="../Gen3/Wild3.cpp" line="88"/>
+        <location filename="../Gen3/Wild3.cpp" line="78"/>
+        <location filename="../Gen3/Wild3.cpp" line="89"/>
         <source>Vital Spirit</source>
         <translation>干劲</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="96"/>
+        <location filename="../Gen3/Wild3.cpp" line="97"/>
         <source>Generate times for seed</source>
         <translation>为Seed生成时间</translation>
     </message>
@@ -9333,8 +9327,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>厉害钓竿</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="80"/>
-        <location filename="../Gen3/Wild3.cpp" line="91"/>
+        <location filename="../Gen3/Wild3.cpp" line="81"/>
+        <location filename="../Gen3/Wild3.cpp" line="92"/>
         <source>Synchronize</source>
         <translation>同步</translation>
     </message>
@@ -9359,8 +9353,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>检索器</translation>
     </message>
     <message>
-        <location filename="../Gen3/Wild3.cpp" line="72"/>
-        <location filename="../Gen3/Wild3.cpp" line="83"/>
+        <location filename="../Gen3/Wild3.cpp" line="73"/>
+        <location filename="../Gen3/Wild3.cpp" line="84"/>
         <source>Cute Charm</source>
         <translation>迷人身躯</translation>
     </message>
@@ -9407,14 +9401,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>第四世代野生乱数</translation>
@@ -9849,14 +9835,6 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
-    <message>
-        <source>Invalid level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Level filter outside of encounters level range!</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>第五世代野生乱数</translation>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -3471,6 +3471,26 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Level Range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Hidden Grotto</source>
         <translation>隐藏洞穴</translation>
     </message>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -3477,6 +3477,14 @@
 <context>
     <name>HiddenGrotto</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Level Range</source>
         <translation type="unfinished">等级范围</translation>
     </message>
@@ -9176,6 +9184,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 <context>
     <name>Wild3</name>
     <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Gen 3 Wild</source>
         <translation>第三世代野生乱数</translation>
     </message>
@@ -9391,6 +9407,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild4</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 4 Wild</source>
         <translation>第四世代野生乱数</translation>
@@ -9825,6 +9849,14 @@ Profile is missing or has an incompatible SHA cache.</source>
 </context>
 <context>
     <name>Wild5</name>
+    <message>
+        <source>Invalid level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Level filter outside of encounters level range!</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Gen 5 Wild</source>
         <translation>第五世代野生乱数</translation>

--- a/Test/Gen3/EggGenerator3Test.cpp
+++ b/Test/Gen3/EggGenerator3Test.cpp
@@ -107,7 +107,7 @@ void EggGenerator3Test::generate()
     Profile3 profile("-", version, 12345, 54321, false);
 
     Daycare daycare(parentIVs, parentAbility, parentGender, parentItem, parentNature, pokemon, false);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EggGenerator3 generator(0, 9, 0, 0, 9, 0, calibration, minRedraw, maxRedraw, method, compatability, daycare, profile, filter);
 
     auto states = generator.generate(seed, seedPickup);

--- a/Test/Gen3/GameCubeGeneratorTest.cpp
+++ b/Test/Gen3/GameCubeGeneratorTest.cpp
@@ -72,7 +72,7 @@ void GameCubeGeneratorTest::generateChannel()
     Profile3 profile("-", Game::GC, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(9, 0);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeGenerator generator(0, 9, 0, Method::Channel, false, profile, filter);
 
     auto states = generator.generate(seed, staticTemplate);
@@ -122,7 +122,7 @@ void GameCubeGeneratorTest::generateColoShadow()
     Profile3 profile("-", Game::Colosseum, 12345, 54321, false);
 
     const ShadowTemplate *shadowTemplate = Encounters3::getShadowTeam(pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeGenerator generator(0, 9, 0, Method::None, false, profile, filter);
 
     auto states = generator.generate(seed, shadowTemplate);
@@ -174,7 +174,7 @@ void GameCubeGeneratorTest::generateGalesShadow()
     Profile3 profile("-", Game::Gales, 12345, 54321, false);
 
     const ShadowTemplate *shadowTemplate = Encounters3::getShadowTeam(pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeGenerator generator(0, 9, 0, Method::None, unset, profile, filter);
 
     auto states = generator.generate(seed, shadowTemplate);
@@ -226,7 +226,7 @@ void GameCubeGeneratorTest::generateNonLock()
     Profile3 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(8, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeGenerator generator(0, 9, 0, Method::None, false, profile, filter);
 
     auto states = generator.generate(seed, staticTemplate);

--- a/Test/Gen3/GameCubeSearcherTest.cpp
+++ b/Test/Gen3/GameCubeSearcherTest.cpp
@@ -78,7 +78,7 @@ void GameCubeSearcherTest::searchChannel()
     Profile3 profile("-", Game::GC, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(9, 0);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeSearcher searcher(Method::Channel, false, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);
@@ -129,7 +129,7 @@ void GameCubeSearcherTest::searchColoShadow()
     Profile3 profile("-", Game::Colosseum, 12345, 54321, false);
 
     const ShadowTemplate *shadowTemplate = Encounters3::getShadowTeam(pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, shadowTemplate->getType() == ShadowType::EReader ? zero : min,
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, shadowTemplate->getType() == ShadowType::EReader ? zero : min,
                        shadowTemplate->getType() == ShadowType::EReader ? zero : max, natures, powers);
     GameCubeSearcher searcher(Method::None, false, profile, filter);
 
@@ -188,7 +188,7 @@ void GameCubeSearcherTest::searchGalesShadow()
     Profile3 profile("-", Game::Gales, 12345, 54321, false);
 
     const ShadowTemplate *shadowTemplate = Encounters3::getShadowTeam(pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeSearcher searcher(Method::None, unset, profile, filter);
 
     searcher.startSearch(min, max, shadowTemplate);
@@ -239,7 +239,7 @@ void GameCubeSearcherTest::searchNonLock()
     Profile3 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(8, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     GameCubeSearcher searcher(Method::None, false, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);

--- a/Test/Gen3/PokeSpotGeneratorTest.cpp
+++ b/Test/Gen3/PokeSpotGeneratorTest.cpp
@@ -83,7 +83,7 @@ void PokeSpotGeneratorTest::generate()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     PokeSpotGenerator generator(0, 9, 0, 0, 9, 0, profile, filter);
 
     auto states = generator.generate(seed, seed, *encounterArea);

--- a/Test/Gen3/StaticGenerator3Test.cpp
+++ b/Test/Gen3/StaticGenerator3Test.cpp
@@ -81,7 +81,7 @@ void StaticGenerator3Test::generate()
     Profile3 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator3 generator(0, 9, 0, method, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen3/StaticSearcher3Test.cpp
+++ b/Test/Gen3/StaticSearcher3Test.cpp
@@ -75,7 +75,7 @@ void StaticSearcher3Test::search()
     Profile3 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate3 *staticTemplate = Encounters3::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticSearcher3 searcher(method, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);

--- a/Test/Gen3/WildGenerator3Test.cpp
+++ b/Test/Gen3/WildGenerator3Test.cpp
@@ -99,7 +99,7 @@ void WildGenerator3Test::generate()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea3 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator3 generator(0, 9, 0, method, lead, settings.feebasTile, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen3/WildSearcher3Test.cpp
+++ b/Test/Gen3/WildSearcher3Test.cpp
@@ -98,7 +98,7 @@ void WildSearcher3Test::search()
         = std::ranges::find_if(encounterAreas.begin(), encounterAreas.end(),
                                [location](const EncounterArea3 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildSearcher3 searcher(method, lead, settings.feebasTile, *encounterArea, profile, filter);
 
     searcher.startSearch(min, max);

--- a/Test/Gen4/EggGenerator4Test.cpp
+++ b/Test/Gen4/EggGenerator4Test.cpp
@@ -98,7 +98,7 @@ void EggGenerator4Test::generate()
     Profile4 profile("-", version, 12345, 54321, false);
 
     Daycare daycare(parentIVs, parentAbility, parentGender, parentItem, parentNature, pokemon, masuda);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EggGenerator4 generator(0, 9, 0, 0, 9, 0, daycare, profile, filter);
 
     auto states = generator.generate(seed, seedPickup);

--- a/Test/Gen4/StaticGenerator4Test.cpp
+++ b/Test/Gen4/StaticGenerator4Test.cpp
@@ -82,7 +82,7 @@ void StaticGenerator4Test::generateMethod1()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator4 generator(0, 9, 0, Method::Method1, Lead::None, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed);
@@ -139,7 +139,7 @@ void StaticGenerator4Test::generateMethodJ()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator4 generator(0, 9, 0, Method::MethodJ, lead, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed);
@@ -196,7 +196,7 @@ void StaticGenerator4Test::generateMethodK()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator4 generator(0, 9, 0, Method::MethodK, lead, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen4/StaticSearcher4Test.cpp
+++ b/Test/Gen4/StaticSearcher4Test.cpp
@@ -91,7 +91,7 @@ void StaticSearcher4Test::searchMethod1()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::Method1, Lead::None, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);
@@ -156,7 +156,7 @@ void StaticSearcher4Test::searchMethodJ()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::MethodJ, lead, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);
@@ -222,7 +222,7 @@ void StaticSearcher4Test::searchMethodK()
     Profile4 profile("-", version, 12345, 54321, false);
 
     const StaticTemplate4 *staticTemplate = Encounters4::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::MethodK, lead, profile, filter);
 
     searcher.startSearch(min, max, staticTemplate);

--- a/Test/Gen4/WildGenerator4Test.cpp
+++ b/Test/Gen4/WildGenerator4Test.cpp
@@ -101,7 +101,7 @@ void WildGenerator4Test::generateMethodJ()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator4 generator(0, 9, 0, Method::MethodJ, lead, settings.dppt.feebasTile, false, false, 50, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed, 0);
@@ -171,7 +171,7 @@ void WildGenerator4Test::generateMethodK()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator4 generator(0, 9, 0, Method::MethodK, lead, false, false, false, 50, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed, 0);
@@ -237,7 +237,7 @@ void WildGenerator4Test::generateHoneyTree()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator4 generator(0, 9, 0, Method::HoneyTree, lead, false, false, false, 50, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed, index);
@@ -307,7 +307,7 @@ void WildGenerator4Test::generatePokeRadar()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator4 generator(0, 9, 0, Method::PokeRadar, lead, false, shiny, false, 50, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed, index);

--- a/Test/Gen4/WildSearcher4Test.cpp
+++ b/Test/Gen4/WildSearcher4Test.cpp
@@ -109,7 +109,7 @@ void WildSearcher4Test::searchMethodJ()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::MethodJ, lead, settings.dppt.feebasTile, false, false, 50,
                            *encounterArea, profile, filter);
 
@@ -189,7 +189,7 @@ void WildSearcher4Test::searchMethodK()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::MethodK, lead, false, false, false, 50, *encounterArea,
                            profile, filter);
 
@@ -265,7 +265,7 @@ void WildSearcher4Test::searchHoneyTree()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::HoneyTree, lead, settings.dppt.feebasTile, false, false, 50,
                            *encounterArea, profile, filter);
 
@@ -346,7 +346,7 @@ void WildSearcher4Test::searchPokeRadar()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea4 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildSearcher4 searcher(minAdvance, maxAdvance, minDelay, maxDelay, Method::PokeRadar, lead, false, shiny, false, 50, *encounterArea,
                            profile, filter);
 

--- a/Test/Gen5/DreamRadarGeneratorTest.cpp
+++ b/Test/Gen5/DreamRadarGeneratorTest.cpp
@@ -91,7 +91,7 @@ void DreamRadarGeneratorTest::generate()
         }
     }
 
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     DreamRadarGenerator generator(0, 9, 0, radarTemplates, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen5/EggGenerator5Test.cpp
+++ b/Test/Gen5/EggGenerator5Test.cpp
@@ -92,7 +92,7 @@ void EggGenerator5Test::generate()
                      false, 0, 0, false, false, DSType::DS, Language::English);
 
     Daycare daycare(parentIVs, parentAbility, parentGender, parentItem, parentNature, pokemon, true);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EggGenerator5 generator(0, 9, 0, daycare, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen5/EventGenerator5Test.cpp
+++ b/Test/Gen5/EventGenerator5Test.cpp
@@ -111,7 +111,7 @@ void EventGenerator5Test::generate()
 
     PGF pgf(tid, sid, specie, nature, gender, ability, shiny, level, hp, atk, def, spa, spd, spe, egg);
 
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EventGenerator5 generator(0, 9, 0, pgf, profile, filter);
 
     auto states = generator.generate(seed);

--- a/Test/Gen5/HiddenGrottoGeneratorTest.cpp
+++ b/Test/Gen5/HiddenGrottoGeneratorTest.cpp
@@ -100,7 +100,7 @@ void HiddenGrottoGeneratorTest::pokemon()
         return encounterArea.getLocation() == location;
     });
 
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     HiddenGrottoGenerator generator(0, 9, 0, lead, gender, encounterArea->getPokemon(group, index), profile, filter);
 
     auto states = generator.generate(seed, 0, 0);

--- a/Test/Gen5/StaticGenerator5Test.cpp
+++ b/Test/Gen5/StaticGenerator5Test.cpp
@@ -80,7 +80,7 @@ void StaticGenerator5Test::generateNonWild()
                      false, 0, 0, false, false, DSType::DS, Language::English);
 
     const StaticTemplate5 *staticTemplate = Encounters5::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator5 generator(0, 9, 0, Method::Method5, Lead::None, 0, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed, 0, 0);
@@ -138,7 +138,7 @@ void StaticGenerator5Test::generateWild()
                      false, 0, 0, false, false, DSType::DS, Language::English);
 
     const StaticTemplate5 *staticTemplate = Encounters5::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator5 generator(0, 9, 0, Method::Method5, lead, 0, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed, 0, 0);

--- a/Test/Gen5/WildGenerator5Test.cpp
+++ b/Test/Gen5/WildGenerator5Test.cpp
@@ -93,7 +93,7 @@ void WildGenerator5Test::generate()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea5 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator5 generator(0, 9, 0, Method::Method5, lead, 0, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed, 0, 0);

--- a/Test/Gen8/EggGenerator8Test.cpp
+++ b/Test/Gen8/EggGenerator8Test.cpp
@@ -90,7 +90,7 @@ void EggGenerator8Test::generate()
     Profile8 profile("-", Game::BD, 12345, 54321, false, true, true);
 
     Daycare daycare(parentIVs, parentAbility, parentGender, parentItem, parentNature, pokemon, true);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EggGenerator8 generator(0, 9, 0, 88, daycare, profile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Test/Gen8/EventGenerator8Test.cpp
+++ b/Test/Gen8/EventGenerator8Test.cpp
@@ -103,7 +103,7 @@ void EventGenerator8Test::generate()
     Profile8 profile("-", Game::BD, 12345, 54321, false, false, false);
 
     WB8 wb8(tid, sid, ec, pid, specie, form, gender, egg, nature, ability, shiny, ivCount, level);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     EventGenerator8 generator(0, 9, 0, wb8, profile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Test/Gen8/RaidGeneratorTest.cpp
+++ b/Test/Gen8/RaidGeneratorTest.cpp
@@ -86,7 +86,7 @@ void RaidGeneratorTest::generate()
     const Den *den = Encounters8::getDen(denIndex, rarity);
     Raid raid = den->getRaid(raidIndex, version);
 
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     RaidGenerator generator(0, 9, 0, profile, filter);
 
     auto states = generator.generate(seed, level, raid);

--- a/Test/Gen8/StaticGenerator8Test.cpp
+++ b/Test/Gen8/StaticGenerator8Test.cpp
@@ -83,7 +83,7 @@ void StaticGenerator8Test::generate()
     Profile8 profile("-", Game::BDSP, 12345, 54321, false, false, false);
 
     const StaticTemplate8 *staticTemplate = Encounters8::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator8 generator(0, 9, 0, lead, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed0, seed1);
@@ -137,7 +137,7 @@ void StaticGenerator8Test::generateRoamer()
     Profile8 profile("-", Game::BD, 12345, 54321, false, false, false);
 
     const StaticTemplate8 *staticTemplate = Encounters8::getStaticEncounter(category, pokemon);
-    StateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers);
+    StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
     StaticGenerator8 generator(0, 9, 0, Lead::None, *staticTemplate, profile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Test/Gen8/UndergroundGeneratorTest.cpp
+++ b/Test/Gen8/UndergroundGeneratorTest.cpp
@@ -94,7 +94,7 @@ void UndergroundGeneratorTest::generate()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const UndergroundArea &encounterArea) { return encounterArea.getLocation() == location; });
 
-    UndergroundStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterArea->getSpecies());
+    UndergroundStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterArea->getSpecies());
     UndergroundGenerator generator(0, 9, 0, lead, diglett, levelFlag, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed0, seed1);

--- a/Test/Gen8/WildGenerator8Test.cpp
+++ b/Test/Gen8/WildGenerator8Test.cpp
@@ -98,7 +98,7 @@ void WildGenerator8Test::generateWild()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea8 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator8 generator(0, 9, 0, Method::None, lead, feebasTile, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed0, seed1, 0);
@@ -164,7 +164,7 @@ void WildGenerator8Test::generateHoneyTree()
     auto encounterArea = std::ranges::find_if(
         encounterAreas, [location](const EncounterArea8 &encounterArea) { return encounterArea.getLocation() == location; });
 
-    WildStateFilter filter(255, 255, 255, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
+    WildStateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers, encounterSlots);
     WildGenerator8 generator(0, 9, 0, Method::HoneyTree, lead, false, *encounterArea, profile, filter);
 
     auto states = generator.generate(seed0, seed1, index);


### PR DESCRIPTION
This allows users to search for pokemon that have a specific level for all those encounters that have a level range within just a single encounter slot.

This affects gen 3 surfing, fishing and rock smash, gen 4 surfing, fishing, rock smash, honey tree, headbutt tree, bug catching contest and gen 5 surfing, fishing, rippling surfing & fishing and hidden grottoes

also made selected location a bit more persistent; super annoying that it previously always switched back to the first location in the list when switching encounter types. Now it persists as long as the newly selected encounter type is also available in the same location