### PR TITLE
[Gen 4] Searcher upgrades

### DIFF
--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -8628,6 +8628,11 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation>Stunde</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation></translation>
     </message>
@@ -10990,6 +10995,11 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
         <translation></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
+        <translation>Stunde</translation>
     </message>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -8633,6 +8633,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10994,6 +10999,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
         <translation type="unfinished">Seed</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -8626,6 +8626,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10986,6 +10991,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -8628,6 +8628,11 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation>Avanzamenti</translation>
     </message>
@@ -10989,6 +10994,11 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -8626,6 +8626,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10986,6 +10991,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -8626,6 +8626,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10986,6 +10991,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -8626,6 +8626,11 @@ Profile is missing or has an incompatible SHA cache.</source>
     </message>
     <message>
         <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/StaticModel4.hpp" line="159"/>
         <source>Advances</source>
         <translation>帧数</translation>
     </message>
@@ -10987,6 +10992,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
         <source>Seed</source>
         <translation>Seed</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>
+        <source>Hour</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Model/Gen4/WildModel4.hpp" line="158"/>

--- a/Model/Gen4/EggModel4.cpp
+++ b/Model/Gen4/EggModel4.cpp
@@ -142,7 +142,7 @@ EggSearcherModel4::EggSearcherModel4(QObject *parent) : TableModel(parent), show
 
 int EggSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 16;
+    return 17;
 }
 
 QVariant EggSearcherModel4::data(const QModelIndex &index, int role) const
@@ -157,42 +157,44 @@ QVariant EggSearcherModel4::data(const QModelIndex &index, int role) const
         case 0:
             return QString::number(display.getSeed(), 16).toUpper().rightJustified(8, '0');
         case 1:
-            return state.getAdvances();
+            return display.getSeed() & 0xffff;
         case 2:
-            return state.getPickupAdvances();
+            return state.getAdvances();
         case 3:
-            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+            return state.getPickupAdvances();
         case 4:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case 5:
         {
             u8 shiny = state.getShiny();
             return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
         }
-        case 5:
-            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 6:
-            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 7:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
         case 8:
         case 9:
         case 10:
         case 11:
         case 12:
+        case 13:
             if (showInheritance)
             {
-                u8 inh = state.getInheritance(column - 7);
+                u8 inh = state.getInheritance(column - 8);
                 if (inh)
                 {
                     return inh == 1 ? "A" : "B";
                 }
             }
-            return showStats ? state.getStat(column - 7) : state.getIV(column - 7);
-        case 13:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 8) : state.getIV(column - 8);
         case 14:
-            return state.getHiddenPowerStrength();
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
         case 15:
-            return QString::fromStdString(Translator::getGender(state.getGender()));
+            return state.getHiddenPowerStrength();
         case 16:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        case 17:
             return QString::fromStdString(Translator::getCharacteristic(state.getCharacteristic()));
         }
     }
@@ -211,11 +213,11 @@ QVariant EggSearcherModel4::headerData(int section, Qt::Orientation orientation,
 void EggSearcherModel4::setShowInheritance(bool flag)
 {
     showInheritance = flag;
-    emit dataChanged(index(0, 7), index(rowCount() - 1, 12), { Qt::DisplayRole });
+    emit dataChanged(index(0, 8), index(rowCount() - 1, 13), { Qt::DisplayRole });
 }
 
 void EggSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 7), index(rowCount() - 1, 12), { Qt::DisplayRole });
+    emit dataChanged(index(0, 8), index(rowCount() - 1, 13), { Qt::DisplayRole });
 }

--- a/Model/Gen4/EggModel4.hpp
+++ b/Model/Gen4/EggModel4.hpp
@@ -185,6 +185,7 @@ public slots:
 
 private:
     QStringList header = { tr("Seed"),
+                           tr("Delay"),
                            tr("Held Advances"),
                            tr("Pickup Advances"),
                            tr("PID"),

--- a/Model/Gen4/EventModel4.cpp
+++ b/Model/Gen4/EventModel4.cpp
@@ -110,7 +110,7 @@ EventSearcherModel4::EventSearcherModel4(QObject *parent) : TableModel(parent), 
 
 int EventSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 10;
+    return 11;
 }
 
 QVariant EventSearcherModel4::data(const QModelIndex &index, int role) const
@@ -124,17 +124,19 @@ QVariant EventSearcherModel4::data(const QModelIndex &index, int role) const
         case 0:
             return QString::number(state.getSeed(), 16).toUpper().rightJustified(8, '0');
         case 1:
-            return state.getAdvances();
+            return state.getSeed() & 0xffff;
         case 2:
+            return state.getAdvances();
         case 3:
         case 4:
         case 5:
         case 6:
         case 7:
-            return showStats ? state.getStat(column - 2) : state.getIV(column - 2);
         case 8:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 3) : state.getIV(column - 3);
         case 9:
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+        case 10:
             return state.getHiddenPowerStrength();
         }
     }
@@ -154,5 +156,5 @@ QVariant EventSearcherModel4::headerData(int section, Qt::Orientation orientatio
 void EventSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 2), index(rowCount() - 1, 7), { Qt::DisplayRole });
+    emit dataChanged(index(0, 3), index(rowCount() - 1, 8), { Qt::DisplayRole });
 }

--- a/Model/Gen4/EventModel4.hpp
+++ b/Model/Gen4/EventModel4.hpp
@@ -155,7 +155,7 @@ public slots:
 
 private:
     QStringList header
-        = { tr("Seed"), tr("Advances"), tr("HP"), tr("Atk"), tr("Def"), tr("SpA"), tr("SpD"), tr("Spe"), tr("Hidden"), tr("Power") };
+        = { tr("Seed"), tr("Delay"), tr("Advances"), tr("HP"), tr("Atk"), tr("Def"), tr("SpA"), tr("SpD"), tr("Spe"), tr("Hidden"), tr("Power") };
     bool showStats;
 };
 

--- a/Model/Gen4/StaticModel4.cpp
+++ b/Model/Gen4/StaticModel4.cpp
@@ -127,7 +127,7 @@ StaticSearcherModel4::StaticSearcherModel4(QObject *parent) : TableModel(parent)
 
 int StaticSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 16;
+    return 17;
 }
 
 QVariant StaticSearcherModel4::data(const QModelIndex &index, int role) const
@@ -141,32 +141,34 @@ QVariant StaticSearcherModel4::data(const QModelIndex &index, int role) const
         case 0:
             return QString::number(state.getSeed(), 16).toUpper().rightJustified(8, '0');
         case 1:
-            return state.getAdvances();
+            return state.getSeed() & 0xffff;
         case 2:
-            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+            return state.getAdvances();
         case 3:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case 4:
         {
             u8 shiny = state.getShiny();
             return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
         }
-        case 4:
-            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 5:
-            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 6:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
         case 7:
         case 8:
         case 9:
         case 10:
         case 11:
-            return showStats ? state.getStat(column - 6) : state.getIV(column - 6);
         case 12:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 7) : state.getIV(column - 7);
         case 13:
-            return state.getHiddenPowerStrength();
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
         case 14:
-            return QString::fromStdString(Translator::getGender(state.getGender()));
+            return state.getHiddenPowerStrength();
         case 15:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        case 16:
             return QString::fromStdString(Translator::getCharacteristic(state.getCharacteristic()));
         }
     }
@@ -185,5 +187,5 @@ QVariant StaticSearcherModel4::headerData(int section, Qt::Orientation orientati
 void StaticSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 6), index(rowCount() - 1, 11), { Qt::DisplayRole });
+    emit dataChanged(index(0, 7), index(rowCount() - 1, 12), { Qt::DisplayRole });
 }

--- a/Model/Gen4/StaticModel4.cpp
+++ b/Model/Gen4/StaticModel4.cpp
@@ -127,7 +127,7 @@ StaticSearcherModel4::StaticSearcherModel4(QObject *parent) : TableModel(parent)
 
 int StaticSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 17;
+    return 18;
 }
 
 QVariant StaticSearcherModel4::data(const QModelIndex &index, int role) const
@@ -143,32 +143,34 @@ QVariant StaticSearcherModel4::data(const QModelIndex &index, int role) const
         case 1:
             return state.getSeed() & 0xffff;
         case 2:
-            return state.getAdvances();
+            return (state.getSeed() >> 16) & 0xff;
         case 3:
-            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+            return state.getAdvances();
         case 4:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case 5:
         {
             u8 shiny = state.getShiny();
             return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
         }
-        case 5:
-            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 6:
-            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 7:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
         case 8:
         case 9:
         case 10:
         case 11:
         case 12:
-            return showStats ? state.getStat(column - 7) : state.getIV(column - 7);
         case 13:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 8) : state.getIV(column - 8);
         case 14:
-            return state.getHiddenPowerStrength();
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
         case 15:
-            return QString::fromStdString(Translator::getGender(state.getGender()));
+            return state.getHiddenPowerStrength();
         case 16:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        case 17:
             return QString::fromStdString(Translator::getCharacteristic(state.getCharacteristic()));
         }
     }
@@ -187,5 +189,5 @@ QVariant StaticSearcherModel4::headerData(int section, Qt::Orientation orientati
 void StaticSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 7), index(rowCount() - 1, 12), { Qt::DisplayRole });
+    emit dataChanged(index(0, 8), index(rowCount() - 1, 13), { Qt::DisplayRole });
 }

--- a/Model/Gen4/StaticModel4.hpp
+++ b/Model/Gen4/StaticModel4.hpp
@@ -156,8 +156,8 @@ public slots:
 
 private:
     QStringList header
-        = { tr("Seed"), tr("Delay"), tr("Advances"), tr("PID"),    tr("Shiny"), tr("Nature"), tr("Ability"), tr("HP"),     tr("Atk"),
-            tr("Def"),  tr("SpA"),   tr("SpD"),      tr("Spe"),    tr("Hidden"), tr("Power"),  tr("Gender"),  tr("Characteristic") };
+        = { tr("Seed"), tr("Delay"), tr("Hour"),  tr("Advances"), tr("PID"),    tr("Shiny"), tr("Nature"), tr("Ability"), tr("HP"),
+            tr("Atk"),  tr("Def"),   tr("SpA"),   tr("SpD"),      tr("Spe"),    tr("Hidden"), tr("Power"),  tr("Gender"),  tr("Characteristic") };
     bool showStats;
 };
 

--- a/Model/Gen4/StaticModel4.hpp
+++ b/Model/Gen4/StaticModel4.hpp
@@ -156,8 +156,8 @@ public slots:
 
 private:
     QStringList header
-        = { tr("Seed"), tr("Advances"), tr("PID"), tr("Shiny"), tr("Nature"), tr("Ability"), tr("HP"),     tr("Atk"),
-            tr("Def"),  tr("SpA"),      tr("SpD"), tr("Spe"),   tr("Hidden"), tr("Power"),   tr("Gender"), tr("Characteristic") };
+        = { tr("Seed"), tr("Delay"), tr("Advances"), tr("PID"),    tr("Shiny"), tr("Nature"), tr("Ability"), tr("HP"),     tr("Atk"),
+            tr("Def"),  tr("SpA"),   tr("SpD"),      tr("Spe"),    tr("Hidden"), tr("Power"),  tr("Gender"),  tr("Characteristic") };
     bool showStats;
 };
 

--- a/Model/Gen4/WildModel4.cpp
+++ b/Model/Gen4/WildModel4.cpp
@@ -139,7 +139,7 @@ WildSearcherModel4::WildSearcherModel4(QObject *parent) : TableModel(parent), sh
 
 int WildSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 19;
+    return 20;
 }
 
 QVariant WildSearcherModel4::data(const QModelIndex &index, int role) const
@@ -153,40 +153,42 @@ QVariant WildSearcherModel4::data(const QModelIndex &index, int role) const
         case 0:
             return QString::number(state.getSeed(), 16).toUpper().rightJustified(8, '0');
         case 1:
-            return state.getAdvances();
+            return state.getSeed() & 0xffff;
         case 2:
-            return QString::fromStdString(Translator::getItem(state.getItem()));
+            return state.getAdvances();
         case 3:
+            return QString::fromStdString(Translator::getItem(state.getItem()));
+        case 4:
             return QString("%1: %2")
                 .arg(state.getEncounterSlot())
                 .arg(QString::fromStdString(Translator::getSpecie(state.getSpecie(), state.getForm())));
-        case 4:
-            return state.getLevel();
         case 5:
-            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+            return state.getLevel();
         case 6:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case 7:
         {
             u8 shiny = state.getShiny();
             return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
         }
-        case 7:
-            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 8:
-            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 9:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
         case 10:
         case 11:
         case 12:
         case 13:
         case 14:
-            return showStats ? state.getStat(column - 9) : state.getIV(column - 9);
         case 15:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 10) : state.getIV(column - 10);
         case 16:
-            return state.getHiddenPowerStrength();
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
         case 17:
-            return QString::fromStdString(Translator::getGender(state.getGender()));
+            return state.getHiddenPowerStrength();
         case 18:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        case 19:
             return QString::fromStdString(Translator::getCharacteristic(state.getCharacteristic()));
         }
     }
@@ -205,5 +207,5 @@ QVariant WildSearcherModel4::headerData(int section, Qt::Orientation orientation
 void WildSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 9), index(rowCount() - 1, 14), { Qt::DisplayRole });
+    emit dataChanged(index(0, 10), index(rowCount() - 1, 15), { Qt::DisplayRole });
 }

--- a/Model/Gen4/WildModel4.cpp
+++ b/Model/Gen4/WildModel4.cpp
@@ -139,7 +139,7 @@ WildSearcherModel4::WildSearcherModel4(QObject *parent) : TableModel(parent), sh
 
 int WildSearcherModel4::columnCount(const QModelIndex &parent) const
 {
-    return 20;
+    return 21;
 }
 
 QVariant WildSearcherModel4::data(const QModelIndex &index, int role) const
@@ -155,40 +155,42 @@ QVariant WildSearcherModel4::data(const QModelIndex &index, int role) const
         case 1:
             return state.getSeed() & 0xffff;
         case 2:
-            return state.getAdvances();
+            return (state.getSeed() >> 16) & 0xff;
         case 3:
-            return QString::fromStdString(Translator::getItem(state.getItem()));
+            return state.getAdvances();
         case 4:
+            return QString::fromStdString(Translator::getItem(state.getItem()));
+        case 5:
             return QString("%1: %2")
                 .arg(state.getEncounterSlot())
                 .arg(QString::fromStdString(Translator::getSpecie(state.getSpecie(), state.getForm())));
-        case 5:
-            return state.getLevel();
         case 6:
-            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+            return state.getLevel();
         case 7:
+            return QString::number(state.getPID(), 16).toUpper().rightJustified(8, '0');
+        case 8:
         {
             u8 shiny = state.getShiny();
             return shiny == 2 ? tr("Square") : shiny == 1 ? tr("Star") : tr("No");
         }
-        case 8:
-            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 9:
-            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
+            return QString::fromStdString(Translator::getNature(state.getNature()));
         case 10:
+            return QString("%1: %2").arg(state.getAbility()).arg(QString::fromStdString(Translator::getAbility(state.getAbilityIndex())));
         case 11:
         case 12:
         case 13:
         case 14:
         case 15:
-            return showStats ? state.getStat(column - 10) : state.getIV(column - 10);
         case 16:
-            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
+            return showStats ? state.getStat(column - 11) : state.getIV(column - 11);
         case 17:
-            return state.getHiddenPowerStrength();
+            return QString::fromStdString(Translator::getHiddenPower(state.getHiddenPower()));
         case 18:
-            return QString::fromStdString(Translator::getGender(state.getGender()));
+            return state.getHiddenPowerStrength();
         case 19:
+            return QString::fromStdString(Translator::getGender(state.getGender()));
+        case 20:
             return QString::fromStdString(Translator::getCharacteristic(state.getCharacteristic()));
         }
     }
@@ -207,5 +209,5 @@ QVariant WildSearcherModel4::headerData(int section, Qt::Orientation orientation
 void WildSearcherModel4::setShowStats(bool flag)
 {
     showStats = flag;
-    emit dataChanged(index(0, 10), index(rowCount() - 1, 15), { Qt::DisplayRole });
+    emit dataChanged(index(0, 11), index(rowCount() - 1, 16), { Qt::DisplayRole });
 }

--- a/Model/Gen4/WildModel4.hpp
+++ b/Model/Gen4/WildModel4.hpp
@@ -155,9 +155,9 @@ public slots:
     void setShowStats(bool flag);
 
 private:
-    QStringList header = { tr("Seed"),   tr("Delay"),  tr("Advances"), tr("Item"),   tr("Slot"),  tr("Level"), tr("PID"),
-                           tr("Shiny"),  tr("Nature"), tr("Ability"),  tr("HP"),     tr("Atk"),   tr("Def"),   tr("SpA"),
-                           tr("SpD"),    tr("Spe"),    tr("Hidden"),   tr("Power"),  tr("Gender"), tr("Characteristic") };
+    QStringList header = { tr("Seed"),   tr("Delay"), tr("Hour"),   tr("Advances"), tr("Item"),   tr("Slot"),   tr("Level"),
+                           tr("PID"),    tr("Shiny"), tr("Nature"), tr("Ability"),  tr("HP"),     tr("Atk"),    tr("Def"),
+                           tr("SpA"),    tr("SpD"),   tr("Spe"),    tr("Hidden"),   tr("Power"),  tr("Gender"), tr("Characteristic") };
     bool showStats;
 };
 

--- a/Model/Gen4/WildModel4.hpp
+++ b/Model/Gen4/WildModel4.hpp
@@ -155,9 +155,9 @@ public slots:
     void setShowStats(bool flag);
 
 private:
-    QStringList header = { tr("Seed"),   tr("Advances"), tr("Item"),  tr("Slot"),   tr("Level"),         tr("PID"), tr("Shiny"),
-                           tr("Nature"), tr("Ability"),  tr("HP"),    tr("Atk"),    tr("Def"),           tr("SpA"), tr("SpD"),
-                           tr("Spe"),    tr("Hidden"),   tr("Power"), tr("Gender"), tr("Characteristic") };
+    QStringList header = { tr("Seed"),   tr("Delay"),  tr("Advances"), tr("Item"),   tr("Slot"),  tr("Level"), tr("PID"),
+                           tr("Shiny"),  tr("Nature"), tr("Ability"),  tr("HP"),     tr("Atk"),   tr("Def"),   tr("SpA"),
+                           tr("SpD"),    tr("Spe"),    tr("Hidden"),   tr("Power"),  tr("Gender"), tr("Characteristic") };
     bool showStats;
 };
 


### PR DESCRIPTION
-add delay display to gen 4 searcher tabs so the user can much faster decide what target they wish to go for without needing to look up each delay on seed to time

-add hour display to gen wild and static searchers for time based wild encounters + rotom, so the user doesn't have to open an extra window (seed to time) just to check what results are valid