### PR TITLE
[Gen 4] remove hardcoded tid/sid/game values on the event4 screen and correct logic to propagate profile values to those fields

### DIFF
--- a/Form/Gen4/Event4.cpp
+++ b/Form/Gen4/Event4.cpp
@@ -177,6 +177,10 @@ void Event4::profileIndexChanged(int index)
     if (index >= 0)
     {
         currentProfile = &profiles[index];
+
+        ui->labelProfileTIDValue->setText(QString::number(currentProfile->getTID()));
+        ui->labelProfileSIDValue->setText(QString::number(currentProfile->getSID()));
+        ui->labelProfileGameValue->setText(QString::fromStdString(Translator::getGame(currentProfile->getVersion())));
     }
 }
 

--- a/Form/Gen4/Event4.ui
+++ b/Form/Gen4/Event4.ui
@@ -45,11 +45,7 @@
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QLabel" name="labelProfileTIDValue">
-        <property name="text">
-         <string notr="true">12345</string>
-        </property>
-       </widget>
+       <widget class="QLabel" name="labelProfileTIDValue"/>
       </item>
       <item row="1" column="2">
        <widget class="QLabel" name="labelProfileSID">
@@ -59,11 +55,7 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QLabel" name="labelProfileSIDValue">
-        <property name="text">
-         <string notr="true">54321</string>
-        </property>
-       </widget>
+       <widget class="QLabel" name="labelProfileSIDValue"/>
       </item>
       <item row="0" column="4" rowspan="2">
        <widget class="Line" name="line">
@@ -80,11 +72,7 @@
        </widget>
       </item>
       <item row="0" column="6">
-       <widget class="QLabel" name="labelProfileGameValue">
-        <property name="text">
-         <string>Diamond</string>
-        </property>
-       </widget>
+       <widget class="QLabel" name="labelProfileGameValue"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
remove hardcoded tid/sid/game values from the Event4 ui. update Event4::profileIndexChanged so the values from the selected profile correctly display in the ui