### PR TITLE
1 Bugfix, 2 QOL changes

### DIFF
--- a/Core/Util/Translator.cpp
+++ b/Core/Util/Translator.cpp
@@ -148,7 +148,9 @@ namespace Translator
 
     const std::string &getForm(u16 specie, u8 form)
     {
-        return forms[(form << 11) | specie];
+        static const std::string empty;
+        auto it = forms.find((form << 11) | specie);
+        return it != forms.end() ? it->second : empty;
     }
 
     const std::string &getGame(Game version)
@@ -305,7 +307,7 @@ namespace Translator
     std::string getSpecie(u16 specie, u8 form)
     {
         auto it = forms.find((form << 11) | specie);
-        if (it != forms.end())
+        if (it != forms.end() && !it->second.empty())
         {
             return species[specie - 1] + " (" + it->second + ")";
         }

--- a/Form/Controls/ComboBox.cpp
+++ b/Form/Controls/ComboBox.cpp
@@ -31,6 +31,7 @@ void ComboBox::enableAutoComplete()
 {
     setEditable(true);
     setInsertPolicy(QComboBox::NoInsert);
+    completer()->setFilterMode(Qt::MatchContains);
     completer()->setCompletionMode(QCompleter::PopupCompletion);
 }
 

--- a/Form/Controls/ComboBoxProxy.cpp
+++ b/Form/Controls/ComboBoxProxy.cpp
@@ -81,6 +81,7 @@ void ComboBoxProxy::enableAutoComplete()
 {
     setEditable(true);
     setInsertPolicy(QComboBox::NoInsert);
+    completer()->setFilterMode(Qt::MatchContains);
     completer()->setCompletionMode(QCompleter::PopupCompletion);
 }
 

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -210,6 +210,9 @@ Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
     connect(ui->filterSearcher, &Filter::showStatsChanged, searcherModel, &WildSearcherModel4::setShowStats);
     connect(ui->pushButtonProfileManager, &QPushButton::clicked, this, &Wild4::profileManager);
 
+    ui->comboBoxGeneratorTime->setCurrentIndex(1);
+    ui->comboBoxSearcherTime->setCurrentIndex(1);
+
     updateProfiles();
     generatorEncounterIndexChanged(0);
     searcherEncounterIndexChanged(0);

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -210,9 +210,6 @@ Wild4::Wild4(QWidget *parent) : QWidget(parent), ui(new Ui::Wild4)
     connect(ui->filterSearcher, &Filter::showStatsChanged, searcherModel, &WildSearcherModel4::setShowStats);
     connect(ui->pushButtonProfileManager, &QPushButton::clicked, this, &Wild4::profileManager);
 
-    ui->comboBoxGeneratorTime->setCurrentIndex(1);
-    ui->comboBoxSearcherTime->setCurrentIndex(1);
-
     updateProfiles();
     generatorEncounterIndexChanged(0);
     searcherEncounterIndexChanged(0);

--- a/Form/Gen4/Wild4.ui
+++ b/Form/Gen4/Wild4.ui
@@ -276,6 +276,9 @@
           </item>
           <item row="3" column="2" colspan="2">
            <widget class="QComboBox" name="comboBoxGeneratorTime">
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
             <item>
              <property name="text">
               <string>Morning</string>
@@ -752,6 +755,9 @@
           </item>
           <item row="3" column="2" colspan="2">
            <widget class="QComboBox" name="comboBoxSearcherTime">
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
             <item>
              <property name="text">
               <string>Morning</string>


### PR DESCRIPTION
-fixing visual bug that made pokemon names sometimes have () behind them

-expand ComboBox autofill to also suggest autofills if the user inputs later parts of the word (e.g. alph for ruins of alph)

-change gen 4 wild default time to day since its the largest time window thus making it most likely to be the currently relevant one on average