### PR TITLE
[Gen 5] Addition of N's pokemon released checkbox for gen 5 profiles

### DIFF
--- a/Core/Gen5/Generators/WildGenerator5.cpp
+++ b/Core/Gen5/Generators/WildGenerator5.cpp
@@ -90,6 +90,11 @@ static u16 getItem(BWRNG &rng, bool bw, Lead lead, Encounter encounter, const Pe
     return 0;
 }
 
+static bool usesNsPokemonReleasedOffset(Encounter encounter)
+{
+    return encounter == Encounter::Grass || encounter == Encounter::GrassDark || encounter == Encounter::Surfing;
+}
+
 WildGenerator5::WildGenerator5(u32 initialAdvances, u32 maxAdvances, u32 offset, Method method, Lead lead, u8 luckyPower,
                                const EncounterArea5 &area, const Profile5 &profile, const WildStateFilter &filter) :
     WildGenerator(initialAdvances, maxAdvances, offset, method, lead, area, profile, filter),
@@ -154,9 +159,17 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
     }
 
     std::vector<WildState5> states;
+    bool nsPokemonReleasedOffset
+        = profile.getMemoryLink() && profile.getNsPokemonReleased() && usesNsPokemonReleasedOffset(area.getEncounter());
     for (u32 cnt = 0; cnt <= maxAdvances; cnt++)
     {
-        BWRNG go(rng, jump);
+        BWRNG rowRng(rng, jump);
+        BWRNG payloadRng = rng;
+        if (nsPokemonReleasedOffset)
+        {
+            payloadRng.next();
+        }
+        BWRNG go(payloadRng, jump);
 
         bool cuteCharm = false;
         bool magnetStatic = false;
@@ -172,7 +185,17 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
             }
             else
             {
-                bool flag = getPercentRand(go, bw) >= 50;
+                bool flag;
+                if (nsPokemonReleasedOffset && lead <= Lead::SynchronizeEnd)
+                {
+                    flag = getPercentRand(rowRng, bw) >= 50;
+                    getPercentRand(go, bw);
+                }
+                else
+                {
+                    flag = getPercentRand(go, bw) >= 50;
+                }
+
                 if (lead == Lead::MagnetPull || lead == Lead::Static)
                 {
                     magnetStatic = flag;

--- a/Core/Gen5/Generators/WildGenerator5.cpp
+++ b/Core/Gen5/Generators/WildGenerator5.cpp
@@ -91,11 +91,6 @@ static u16 getItem(BWRNG &rng, bool bw, Lead lead, Encounter encounter, const Pe
     return 0;
 }
 
-static bool usesNsPokemonReleasedOffset(Encounter encounter)
-{
-    return encounter == Encounter::Grass || encounter == Encounter::GrassDark || encounter == Encounter::Surfing;
-}
-
 WildGenerator5::WildGenerator5(u32 initialAdvances, u32 maxAdvances, u32 offset, Method method, Lead lead, PassPower luckyPower,
                                const EncounterArea5 &area, const Profile5 &profile, const WildStateFilter &filter) :
     WildGenerator(initialAdvances, maxAdvances, offset, method, lead, area, profile, filter),
@@ -159,18 +154,12 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
         }
     }
 
+    bool nsPokemonReleasedOffset = profile.getMemoryLink() && profile.getNsPokemonReleased() && area.getEncounter() != Encounter::SuperRod;
+
     std::vector<WildState5> states;
-    bool nsPokemonReleasedOffset
-        = profile.getMemoryLink() && profile.getNsPokemonReleased() && usesNsPokemonReleasedOffset(area.getEncounter());
     for (u32 cnt = 0; cnt <= maxAdvances; cnt++)
     {
-        BWRNG rowRng(rng, jump);
-        BWRNG payloadRng = rng;
-        if (nsPokemonReleasedOffset)
-        {
-            payloadRng.next();
-        }
-        BWRNG go(payloadRng, jump);
+        BWRNG go(rng, jump);
 
         bool cuteCharm = false;
         bool magnetStatic = false;
@@ -186,17 +175,7 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
             }
             else
             {
-                bool flag;
-                if (nsPokemonReleasedOffset && lead <= Lead::SynchronizeEnd)
-                {
-                    flag = getPercentRand(rowRng, bw) >= 50;
-                    getPercentRand(go, bw);
-                }
-                else
-                {
-                    flag = getPercentRand(go, bw) >= 50;
-                }
-
+                bool flag = getPercentRand(go, bw) >= 50;
                 if (lead == Lead::MagnetPull || lead == Lead::Static)
                 {
                     magnetStatic = flag;
@@ -216,6 +195,11 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
         if (area.getEncounter() == Encounter::GrassDark && getPercentRand(go, bw) < 40)
         {
             doubleBattle = true;
+        }
+
+        if (nsPokemonReleasedOffset)
+        {
+            go.next();
         }
 
         if (area.getEncounter() == Encounter::SuperRod && getPercentRand(go, bw) > rate)

--- a/Core/Gen5/Generators/WildGenerator5.cpp
+++ b/Core/Gen5/Generators/WildGenerator5.cpp
@@ -154,7 +154,8 @@ std::vector<WildState5> WildGenerator5::generate(u64 seed, const std::vector<std
         }
     }
 
-    bool nsPokemonReleasedOffset = profile.getMemoryLink() && profile.getNsPokemonReleased() && area.getEncounter() != Encounter::SuperRod;
+    bool nsPokemonReleasedOffset = profile.getMemoryLink() && profile.getNsPokemonReleased()
+        && (area.getEncounter() != Encounter::SuperRod && area.getEncounter() != Encounter::SuperRodRippling);
 
     std::vector<WildState5> states;
     for (u32 cnt = 0; cnt <= maxAdvances; cnt++)

--- a/Core/Gen5/Profile5.cpp
+++ b/Core/Gen5/Profile5.cpp
@@ -80,7 +80,8 @@ bool Profile5::operator==(const Profile5 &other) const
     return Profile::operator==(other) && ivCache == other.ivCache && shaCache == other.shaCache && mac == other.mac
         && keypresses == other.keypresses && vcount == other.vcount && gxstat == other.gxstat && vframe == other.vframe
         && skipLR == other.skipLR && timer0Min == other.timer0Min && timer0Max == other.timer0Max && memoryLink == other.memoryLink
-        && shinyCharm == other.shinyCharm && dsType == other.dsType && language == other.language;
+        && nsPokemonReleased == other.nsPokemonReleased && shinyCharm == other.shinyCharm && dsType == other.dsType
+        && language == other.language;
 }
 
 bool Profile5::operator!=(const Profile5 &other) const

--- a/Core/Gen5/Profile5.hpp
+++ b/Core/Gen5/Profile5.hpp
@@ -53,10 +53,11 @@ public:
      * @param shinyCharm Whether shiny charm is obtained
      * @param dsType DS type for the profile
      * @param language Language type of the profile
+     * @param nsPokemonReleased Whether N's Pokemon have been released
      */
     Profile5(const std::string &name, Game version, u16 tid, u16 sid, const std::string &ivCache, const std::string &shaCache, u64 mac,
              const std::array<bool, 9> &keypresses, u8 vcount, u8 gxstat, u8 vframe, bool skipLR, u16 timer0Min, u16 timer0Max,
-             bool memoryLink, bool shinyCharm, DSType dsType, Language language) :
+             bool memoryLink, bool shinyCharm, DSType dsType, Language language, bool nsPokemonReleased = false) :
         Profile(name, version, tid, sid),
         ivCache(ivCache),
         shaCache(shaCache),
@@ -64,6 +65,7 @@ public:
         timer0Max(timer0Max),
         timer0Min(timer0Min),
         memoryLink(memoryLink),
+        nsPokemonReleased(nsPokemonReleased),
         shinyCharm(shinyCharm),
         skipLR(skipLR),
         dsType(dsType),
@@ -168,6 +170,17 @@ public:
     }
 
     /**
+     * @brief Returns if N's Pokemon have been released
+     *
+     * @return true N's Pokemon have been released
+     * @return false N's Pokemon have not been released
+     */
+    bool getNsPokemonReleased() const
+    {
+        return nsPokemonReleased;
+    }
+
+    /**
      * @brief Returns the profile SHA cache path
      *
      * @return Profile SHA cache path
@@ -266,6 +279,7 @@ private:
     u16 timer0Max;
     u16 timer0Min;
     bool memoryLink;
+    bool nsPokemonReleased;
     bool shinyCharm;
     bool skipLR;
     DSType dsType;

--- a/Core/Gen5/Profile5.hpp
+++ b/Core/Gen5/Profile5.hpp
@@ -50,14 +50,14 @@ public:
      * @param timer0Min Minimum Timer0 value
      * @param timer0Max Maximum Timer0 value
      * @param memoryLink Whether memory link is activated
+     * @param nsPokemonReleased Whether N's Pokemon have been released
      * @param shinyCharm Whether shiny charm is obtained
      * @param dsType DS type for the profile
      * @param language Language type of the profile
-     * @param nsPokemonReleased Whether N's Pokemon have been released
      */
     Profile5(const std::string &name, Game version, u16 tid, u16 sid, const std::string &ivCache, const std::string &shaCache, u64 mac,
              const std::array<bool, 9> &keypresses, u8 vcount, u8 gxstat, u8 vframe, bool skipLR, u16 timer0Min, u16 timer0Max,
-             bool memoryLink, bool shinyCharm, DSType dsType, Language language, bool nsPokemonReleased = false) :
+             bool memoryLink, bool nsPokemonReleased, bool shinyCharm, DSType dsType, Language language) :
         Profile(name, version, tid, sid),
         ivCache(ivCache),
         shaCache(shaCache),

--- a/Core/Parents/ProfileLoader.cpp
+++ b/Core/Parents/ProfileLoader.cpp
@@ -340,6 +340,7 @@ namespace ProfileLoader5
             j["timer0Min"] = profile.getTimer0Min();
             j["timer0Max"] = profile.getTimer0Max();
             j["memoryLink"] = profile.getMemoryLink();
+            j["nsPokemonReleased"] = profile.getNsPokemonReleased();
             j["shinyCharm"] = profile.getShinyCharm();
             j["dsType"] = profile.getDSType();
             j["language"] = profile.getLanguage();
@@ -384,11 +385,12 @@ namespace ProfileLoader5
             u16 timer0Min = j.value("timer0Min", 0);
             u16 timer0Max = j.value("timer0Max", 0);
             bool memoryLink = j.value("memoryLink", false);
+            bool nsPokemonReleased = memoryLink && j.value("nsPokemonReleased", false);
             bool shinyCharm = j.value("shinyCharm", false);
             DSType dsType = j.value("dsType", DSType::DS);
             Language language = j.value("language", Language::English);
             return Profile5(name, version, tid, sid, ivCache, shaCache, mac, keypresses, vcount, gxstat, vframe, skipLR, timer0Min,
-                            timer0Max, memoryLink, shinyCharm, dsType, language);
+                            timer0Max, memoryLink, shinyCharm, dsType, language, nsPokemonReleased);
         }
 
     }

--- a/Core/Parents/ProfileLoader.cpp
+++ b/Core/Parents/ProfileLoader.cpp
@@ -390,7 +390,7 @@ namespace ProfileLoader5
             DSType dsType = j.value("dsType", DSType::DS);
             Language language = j.value("language", Language::English);
             return Profile5(name, version, tid, sid, ivCache, shaCache, mac, keypresses, vcount, gxstat, vframe, skipLR, timer0Min,
-                            timer0Max, memoryLink, shinyCharm, dsType, language, nsPokemonReleased);
+                            timer0Max, memoryLink, nsPokemonReleased, shinyCharm, dsType, language);
         }
 
     }

--- a/Form/Gen5/Profile/ProfileEditor5.cpp
+++ b/Form/Gen5/Profile/ProfileEditor5.cpp
@@ -59,6 +59,13 @@ ProfileEditor5::ProfileEditor5(QWidget *parent) : QDialog(parent), ui(new Ui::Pr
     connect(ui->pushButtonSelectSHACache, &QPushButton::clicked, this, &ProfileEditor5::selectSHACache);
     connect(ui->pushButtonClearIVCache, &QPushButton::clicked, this, &ProfileEditor5::clearIVCache);
     connect(ui->pushButtonClearSHACache, &QPushButton::clicked, this, &ProfileEditor5::clearSHACache);
+    connect(ui->checkBoxMemoryLink, &QCheckBox::toggled, this, [this](bool checked) {
+        ui->checkBoxNsPokemonReleased->setEnabled(checked);
+        if (!checked)
+        {
+            ui->checkBoxNsPokemonReleased->setChecked(false);
+        }
+    });
 
     versionIndexChanged(ui->comboBoxVersion->currentIndex());
 }
@@ -85,6 +92,7 @@ ProfileEditor5::ProfileEditor5(const Profile5 &profile, QWidget *parent) : Profi
 
     ui->checkBoxSkipLR->setChecked(profile.getSkipLR());
     ui->checkBoxMemoryLink->setChecked(profile.getMemoryLink());
+    ui->checkBoxNsPokemonReleased->setChecked(profile.getMemoryLink() && profile.getNsPokemonReleased());
     ui->checkBoxShinyCharm->setChecked(profile.getShinyCharm());
 }
 
@@ -115,7 +123,8 @@ Profile5 ProfileEditor5::getProfile()
                     ui->textBoxMAC->getULong(), ui->comboBoxKeypresses->getCheckedArray<9>(), ui->textBoxVCount->getUChar(),
                     ui->textBoxGxStat->getUChar(), ui->textBoxVFrame->getUChar(), ui->checkBoxSkipLR->isChecked(),
                     ui->textBoxTimer0Min->getUShort(), ui->textBoxTimer0Max->getUShort(), ui->checkBoxMemoryLink->isChecked(),
-                    ui->checkBoxShinyCharm->isChecked(), ui->comboBoxDSType->getEnum<DSType>(), ui->comboBoxLanguage->getEnum<Language>());
+                    ui->checkBoxShinyCharm->isChecked(), ui->comboBoxDSType->getEnum<DSType>(), ui->comboBoxLanguage->getEnum<Language>(),
+                    ui->checkBoxMemoryLink->isChecked() && ui->checkBoxNsPokemonReleased->isChecked());
 }
 
 void ProfileEditor5::clearIVCache()
@@ -192,12 +201,16 @@ void ProfileEditor5::versionIndexChanged(int index)
         if ((version & Game::BW2) != Game::None)
         {
             ui->checkBoxMemoryLink->show();
+            ui->checkBoxNsPokemonReleased->show();
+            ui->checkBoxNsPokemonReleased->setEnabled(ui->checkBoxMemoryLink->isChecked());
             ui->checkBoxShinyCharm->show();
         }
         else
         {
             ui->checkBoxMemoryLink->hide();
             ui->checkBoxMemoryLink->setChecked(false);
+            ui->checkBoxNsPokemonReleased->hide();
+            ui->checkBoxNsPokemonReleased->setChecked(false);
             ui->checkBoxShinyCharm->hide();
             ui->checkBoxShinyCharm->setChecked(false);
         }

--- a/Form/Gen5/Profile/ProfileEditor5.cpp
+++ b/Form/Gen5/Profile/ProfileEditor5.cpp
@@ -54,18 +54,12 @@ ProfileEditor5::ProfileEditor5(QWidget *parent) : QDialog(parent), ui(new Ui::Pr
     connect(ui->pushButtonAccept, &QPushButton::clicked, this, &ProfileEditor5::okay);
     connect(ui->pushButtonCancel, &QPushButton::clicked, this, &ProfileEditor5::reject);
     connect(ui->pushButtonFindParameters, &QPushButton::clicked, this, &ProfileEditor5::findParameters);
+    connect(ui->checkBoxMemoryLink, &QCheckBox::toggled, this, &ProfileEditor5::memoryLinkToggled);
     connect(ui->comboBoxVersion, &QComboBox::currentIndexChanged, this, &ProfileEditor5::versionIndexChanged);
     connect(ui->pushButtonSelectIVCache, &QPushButton::clicked, this, &ProfileEditor5::selectIVCache);
     connect(ui->pushButtonSelectSHACache, &QPushButton::clicked, this, &ProfileEditor5::selectSHACache);
     connect(ui->pushButtonClearIVCache, &QPushButton::clicked, this, &ProfileEditor5::clearIVCache);
     connect(ui->pushButtonClearSHACache, &QPushButton::clicked, this, &ProfileEditor5::clearSHACache);
-    connect(ui->checkBoxMemoryLink, &QCheckBox::toggled, this, [this](bool checked) {
-        ui->checkBoxNsPokemonReleased->setEnabled(checked);
-        if (!checked)
-        {
-            ui->checkBoxNsPokemonReleased->setChecked(false);
-        }
-    });
 
     versionIndexChanged(ui->comboBoxVersion->currentIndex());
 }
@@ -123,8 +117,8 @@ Profile5 ProfileEditor5::getProfile()
                     ui->textBoxMAC->getULong(), ui->comboBoxKeypresses->getCheckedArray<9>(), ui->textBoxVCount->getUChar(),
                     ui->textBoxGxStat->getUChar(), ui->textBoxVFrame->getUChar(), ui->checkBoxSkipLR->isChecked(),
                     ui->textBoxTimer0Min->getUShort(), ui->textBoxTimer0Max->getUShort(), ui->checkBoxMemoryLink->isChecked(),
-                    ui->checkBoxShinyCharm->isChecked(), ui->comboBoxDSType->getEnum<DSType>(), ui->comboBoxLanguage->getEnum<Language>(),
-                    ui->checkBoxMemoryLink->isChecked() && ui->checkBoxNsPokemonReleased->isChecked());
+                    ui->checkBoxMemoryLink->isChecked() && ui->checkBoxNsPokemonReleased->isChecked(), ui->checkBoxShinyCharm->isChecked(),
+                    ui->comboBoxDSType->getEnum<DSType>(), ui->comboBoxLanguage->getEnum<Language>());
 }
 
 void ProfileEditor5::clearIVCache()
@@ -157,6 +151,15 @@ void ProfileEditor5::okay()
     }
 
     done(QDialog::Accepted);
+}
+
+void ProfileEditor5::memoryLinkToggled(bool checked)
+{
+    ui->checkBoxNsPokemonReleased->setEnabled(checked);
+    if (!checked)
+    {
+        ui->checkBoxNsPokemonReleased->setChecked(false);
+    }
 }
 
 void ProfileEditor5::selectIVCache()

--- a/Form/Gen5/Profile/ProfileEditor5.hpp
+++ b/Form/Gen5/Profile/ProfileEditor5.hpp
@@ -106,6 +106,13 @@ private slots:
     void okay();
 
     /**
+     * @brief Toggles whether N's Pokemon Released is enabled based on memory link
+     *
+     * @param checked Current check status of memory link
+     */
+    void memoryLinkToggled(bool checked);
+
+    /**
      * @brief Prompts user to select IV cache
      */
     void selectIVCache();

--- a/Form/Gen5/Profile/ProfileEditor5.ui
+++ b/Form/Gen5/Profile/ProfileEditor5.ui
@@ -270,6 +270,13 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="6">
+    <widget class="QCheckBox" name="checkBoxNsPokemonReleased">
+     <property name="text">
+      <string>N's Pokémon released</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="7">
     <widget class="QCheckBox" name="checkBoxShinyCharm">
      <property name="text">
@@ -395,6 +402,7 @@
   <tabstop>textBoxTID</tabstop>
   <tabstop>textBoxSID</tabstop>
   <tabstop>checkBoxMemoryLink</tabstop>
+  <tabstop>checkBoxNsPokemonReleased</tabstop>
   <tabstop>checkBoxShinyCharm</tabstop>
   <tabstop>checkBoxSkipLR</tabstop>
   <tabstop>lineEditIVCache</tabstop>

--- a/Form/Util/EncounterLookup.cpp
+++ b/Form/Util/EncounterLookup.cpp
@@ -240,7 +240,7 @@ std::set<std::pair<u16, QString>> EncounterLookup::getEncounters5(Game version, 
 {
     std::set<std::pair<u16, QString>> encounters;
     Profile5 profile("", version, 0, 0, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0, false, 0, 0,
-                     false, false, DSType::DS, Language::English);
+                     false, false, false, DSType::DS, Language::English);
 
     // Encounter variables to iterate through
     auto types

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -5851,6 +5851,10 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Mementolink</translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation>Ns Pokémon freigelassen</translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation>Schillerpin</translation>
     </message>
@@ -6347,7 +6351,12 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Mementolink</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation>Ns Pokémon freigelassen</translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation>Schillerpin</translation>
     </message>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -5847,7 +5847,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Mementolink</translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation>Ns Pokémon freigelassen</translation>
     </message>
     <message>
@@ -5855,42 +5855,42 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Schillerpin</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation>Profilname eingeben</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation>Fehlender Name</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation>IV Cache öffnen</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation>Ungültiges IV Cache</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation>Datei ist kein gültiges IV Cache</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation>Ungültiges SHA Cache</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation>Datei ist kein gültiges SHA Cache oder wurde nicht aus dem Profil erstellt</translation>
     </message>
@@ -6266,6 +6266,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
@@ -6273,6 +6274,7 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
@@ -6347,8 +6349,8 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation>Mementolink</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation>Ns Pokémon freigelassen</translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -5851,6 +5851,10 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6347,7 +6351,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -5847,7 +5847,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5855,42 +5855,42 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation>Introduzca un nombre de perfil</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6266,6 +6266,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation type="unfinished">Sí</translation>
     </message>
@@ -6273,6 +6274,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
@@ -6347,8 +6349,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -5850,6 +5850,10 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,7 +6350,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -5846,7 +5846,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5854,42 +5854,42 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6265,6 +6265,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6272,6 +6273,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,8 +6348,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -5851,6 +5851,10 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Asse dei Ricordi</translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation>Cromamuleto</translation>
     </message>
@@ -6347,7 +6351,12 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Asse dei Ricordi</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation>Cromamuleto</translation>
     </message>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -5847,7 +5847,7 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Asse dei Ricordi</translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5855,42 +5855,42 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Cromamuleto</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation>Inserisci un nome profilo</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation>Nome mancante</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation>Apri Cache IV</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation>Cache IV non valide</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation>Il file fornito non è una valida Cache IV</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation>Apri Cache SHA1</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation>Cache SHA non valida</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation>Il file fornito non è una Cache SHA valida o non è stato creato dal profilo corrente</translation>
     </message>
@@ -6266,6 +6266,7 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
@@ -6273,6 +6274,7 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6347,8 +6349,8 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation>Asse dei Ricordi</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -5850,6 +5850,10 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,7 +6350,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -5846,7 +5846,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5854,42 +5854,42 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6265,6 +6265,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6272,6 +6273,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,8 +6348,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -5850,6 +5850,10 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,7 +6350,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -5846,7 +5846,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5854,42 +5854,42 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6265,6 +6265,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6272,6 +6273,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6346,8 +6348,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -5850,6 +5850,10 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>记忆连接</translation>
     </message>
     <message>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shiny Charm</source>
         <translation>闪耀护符</translation>
     </message>
@@ -6346,7 +6350,12 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>记忆连接</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
+        <source>N's Pokémon released</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
         <source>Shiny Charm</source>
         <translation>闪耀护符</translation>
     </message>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -5846,7 +5846,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>记忆连接</translation>
     </message>
     <message>
-        <source>N's Pokémon released</source>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5854,42 +5854,42 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>闪耀护符</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Enter a profile name</source>
         <translation>请输入存档名</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="145"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="148"/>
         <source>Missing name</source>
         <translation>未输入存档名</translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="155"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="167"/>
         <source>Open IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Invalid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="164"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="176"/>
         <source>Provided file is not a valid IV Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="172"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="184"/>
         <source>Open SHA1 Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="180"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="192"/>
         <source>Invalid SHA Cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="181"/>
+        <location filename="../Gen5/Profile/ProfileEditor5.cpp" line="193"/>
         <source>Provided file is not a valid SHA Cache or was not created from the profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6265,6 +6265,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
@@ -6272,6 +6273,7 @@ Profile is missing or has an incompatible SHA cache.</source>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="64"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="66"/>
         <location filename="../../Model/Gen5/ProfileModel5.cpp" line="68"/>
+        <location filename="../../Model/Gen5/ProfileModel5.cpp" line="70"/>
         <source>No</source>
         <translation>否</translation>
     </message>
@@ -6346,8 +6348,8 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation>记忆连接</translation>
     </message>
     <message>
-        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="74"/>
-        <source>N's Pokémon released</source>
+        <location filename="../../Model/Gen5/ProfileModel5.hpp" line="73"/>
+        <source>N&apos;s Pokémon released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Model/Gen5/ProfileModel5.cpp
+++ b/Model/Gen5/ProfileModel5.cpp
@@ -26,7 +26,7 @@ ProfileModel5::ProfileModel5(QObject *parent) : TableModel(parent)
 
 int ProfileModel5::columnCount(const QModelIndex &parent) const
 {
-    return 15;
+    return 16;
 }
 
 QVariant ProfileModel5::data(const QModelIndex &index, int role) const
@@ -65,6 +65,8 @@ QVariant ProfileModel5::data(const QModelIndex &index, int role) const
         case 13:
             return profile.getMemoryLink() ? tr("Yes") : tr("No");
         case 14:
+            return profile.getNsPokemonReleased() ? tr("Yes") : tr("No");
+        case 15:
             return profile.getShinyCharm() ? tr("Yes") : tr("No");
         }
     }

--- a/Model/Gen5/ProfileModel5.hpp
+++ b/Model/Gen5/ProfileModel5.hpp
@@ -70,7 +70,8 @@ public:
 private:
     QStringList header = { tr("Profile Name"), tr("Version"),    tr("Language"), tr("TID"),         tr("SID"),
                            tr("MAC Address"),  tr("DS Type"),    tr("VCount"),   tr("Timer0"),      tr("GxStat"),
-                           tr("VFrame"),       tr("Keypresses"), tr("Skip L/R"), tr("Memory Link"), tr("Shiny Charm") };
+                           tr("VFrame"),       tr("Keypresses"), tr("Skip L/R"), tr("Memory Link"),
+                           tr("N's Pokémon released"), tr("Shiny Charm") };
 };
 
 #endif // PROFILE5MODEL_HPP

--- a/Model/Gen5/ProfileModel5.hpp
+++ b/Model/Gen5/ProfileModel5.hpp
@@ -70,8 +70,8 @@ public:
 private:
     QStringList header = { tr("Profile Name"), tr("Version"),    tr("Language"), tr("TID"),         tr("SID"),
                            tr("MAC Address"),  tr("DS Type"),    tr("VCount"),   tr("Timer0"),      tr("GxStat"),
-                           tr("VFrame"),       tr("Keypresses"), tr("Skip L/R"), tr("Memory Link"),
-                           tr("N's Pokémon released"), tr("Shiny Charm") };
+                           tr("VFrame"),       tr("Keypresses"), tr("Skip L/R"), tr("Memory Link"), tr("N's Pokémon released"),
+                           tr("Shiny Charm") };
 };
 
 #endif // PROFILE5MODEL_HPP

--- a/Test/Gen5/DreamRadarGeneratorTest.cpp
+++ b/Test/Gen5/DreamRadarGeneratorTest.cpp
@@ -77,7 +77,7 @@ void DreamRadarGeneratorTest::generate()
     powers.fill(true);
 
     Profile5 profile("-", Game::BW2, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     const DreamRadarTemplate *dreamRadarTemplates = Encounters5::getDreamRadarEncounters();
 

--- a/Test/Gen5/EggGenerator5Test.cpp
+++ b/Test/Gen5/EggGenerator5Test.cpp
@@ -89,7 +89,7 @@ void EggGenerator5Test::generate()
     powers.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     Daycare daycare(parentIVs, parentAbility, parentGender, parentItem, parentNature, pokemon, true);
     StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);

--- a/Test/Gen5/EventGenerator5Test.cpp
+++ b/Test/Gen5/EventGenerator5Test.cpp
@@ -107,7 +107,7 @@ void EventGenerator5Test::generate()
     powers.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     PGF pgf(tid, sid, specie, nature, gender, ability, shiny, level, hp, atk, def, spa, spd, spe, egg);
 

--- a/Test/Gen5/HiddenGrottoGeneratorTest.cpp
+++ b/Test/Gen5/HiddenGrottoGeneratorTest.cpp
@@ -93,7 +93,7 @@ void HiddenGrottoGeneratorTest::pokemon()
     powers.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     std::vector<HiddenGrottoArea> encounterAreas = Encounters5::getHiddenGrottoEncounters();
     auto encounterArea = std::ranges::find_if(
@@ -146,7 +146,7 @@ void HiddenGrottoGeneratorTest::slot()
     groups.fill(true);
 
     Profile5 profile("-", Game::BW2, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     std::vector<HiddenGrottoArea> encounterAreas = Encounters5::getHiddenGrottoEncounters();
     auto encounterArea = std::ranges::find_if(

--- a/Test/Gen5/IDGenerator5Test.cpp
+++ b/Test/Gen5/IDGenerator5Test.cpp
@@ -55,7 +55,7 @@ void IDGenerator5Test::generate()
     json j = json::parse(results);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     IDFilter filter({ }, { }, { }, { }, { }, { });
     IDGenerator5 generator(0, 9, 0, false, false, profile, filter);

--- a/Test/Gen5/StaticGenerator5Test.cpp
+++ b/Test/Gen5/StaticGenerator5Test.cpp
@@ -77,7 +77,7 @@ void StaticGenerator5Test::generateNonWild()
     powers.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     const StaticTemplate5 *staticTemplate = Encounters5::getStaticEncounter(category, pokemon);
     StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);
@@ -137,7 +137,7 @@ void StaticGenerator5Test::generateWild()
     powers.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     const StaticTemplate5 *staticTemplate = Encounters5::getStaticEncounter(category, pokemon);
     StateFilter filter(255, 255, 255, 1, 100, 0, 255, 0, 255, false, min, max, natures, powers);

--- a/Test/Gen5/WildGenerator5Test.cpp
+++ b/Test/Gen5/WildGenerator5Test.cpp
@@ -89,7 +89,7 @@ void WildGenerator5Test::generate()
     encounterSlots.fill(true);
 
     Profile5 profile("-", version, 12345, 54321, "", "", 0, { false, false, false, false, false, false, false, false, false }, 0, 0, 0,
-                     false, 0, 0, false, false, DSType::DS, Language::English);
+                     false, 0, 0, false, false, false, DSType::DS, Language::English);
 
     std::vector<EncounterArea5> encounterAreas = Encounters5::getEncounters(encounter, 0, &profile);
     auto encounterArea = std::ranges::find_if(

--- a/Test/RNG/SHA1Test.cpp
+++ b/Test/RNG/SHA1Test.cpp
@@ -70,7 +70,7 @@ void SHA1Test::hash()
     QFETCH(DSType, dsType);
     QFETCH(u64, seed);
 
-    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, dsType,
+    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, false, dsType,
                      language);
 
     auto buttons = Keypresses::getKeypresses(profile);
@@ -127,7 +127,7 @@ void SHA1Test::hashTime()
     QFETCH(DSType, dsType);
     QFETCH(u64, seed);
 
-    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, dsType,
+    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, false, dsType,
                      language);
 
     auto buttons = Keypresses::getKeypresses(profile);
@@ -183,7 +183,7 @@ void SHA1SSETest::hash()
     QFETCH(DSType, dsType);
     QFETCH(SeedSSE, seed);
 
-    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, dsType,
+    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, false, dsType,
                      language);
 
     auto buttons = Keypresses::getKeypresses(profile);
@@ -240,7 +240,7 @@ void SHA1SSETest::hashTime()
     QFETCH(DSType, dsType);
     QFETCH(SeedSSE, seed);
 
-    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, dsType,
+    Profile5 profile("-", version, 0, 0, "", "", mac, keypresses, vCount, gxStat, vFrame, skipLR, timer0, timer0, false, false, false, dsType,
                      language);
 
     auto buttons = Keypresses::getKeypresses(profile);


### PR DESCRIPTION
Fixes #571 
With N's Pokemon released, the "wild encounter data" of all Grass, Dark Grass and Surfing encounters is shifted down by 1 whilst the Chatot and what number advances cause a successful synchronize stay on their original advance.