### PR TITLE
[Gen 5] Allow multi item search for Hidden Grottoes

### DIFF
--- a/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
+++ b/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
@@ -77,7 +77,7 @@ std::vector<HiddenGrottoState> HiddenGrottoSlotGenerator::generate(u64 seed) con
             u8 slot = encounterTable[go.nextUInt(100)];
             if (slot < 3) // Pokemon
             {
-                const auto &pokemon = encounterArea.getPokemon(group, slot);
+                auto pokemon = encounterArea.getPokemon(group, slot, profile.getVersion());
                 u8 gender = go.nextUInt(100) < pokemon.getGender();
                 HiddenGrottoState state(prng, advances + initialAdvances + cnt, group, slot, pokemon.getSpecie(), gender);
                 if (filter.compareState(state))

--- a/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
+++ b/Core/Gen5/Generators/HiddenGrottoGenerator.cpp
@@ -109,6 +109,46 @@ std::vector<HiddenGrottoState> HiddenGrottoSlotGenerator::generate(u64 seed) con
     return states;
 }
 
+HiddenGrottoItemGenerator::HiddenGrottoItemGenerator(const HiddenGrottoSlotGenerator &generator, u16 item, u8 amount) :
+    generator(generator), item(item), amount(amount)
+{
+}
+
+std::vector<HiddenGrottoState> HiddenGrottoItemGenerator::generate(u64 seed) const
+{
+    auto states = generator.generate(seed);
+    std::vector<u32> advances;
+    std::vector<HiddenGrottoState> result;
+
+    for (const auto &state : states)
+    {
+        if (!state.getItem() || state.getData() != item)
+        {
+            continue;
+        }
+
+        if (advances.empty() || state.getAdvances() > advances.back() + 5)
+        {
+            if (advances.empty())
+            {
+                result.emplace_back(state);
+            }
+            advances.emplace_back(state.getAdvances());
+        }
+    }
+
+    if (advances.size() >= amount)
+    {
+        result.front().setItemAdvances(advances);
+    }
+    else
+    {
+        result.clear();
+    }
+
+    return result;
+}
+
 HiddenGrottoGenerator::HiddenGrottoGenerator(u32 initialAdvances, u32 maxAdvances, u32 offset, Lead lead, u8 gender,
                                              const HiddenGrottoSlot &slot, const Profile5 &profile, const StateFilter &filter) :
     Generator(initialAdvances, maxAdvances, offset, Method::None, profile, filter), slot(slot), lead(lead), gender(gender)

--- a/Core/Gen5/Generators/HiddenGrottoGenerator.hpp
+++ b/Core/Gen5/Generators/HiddenGrottoGenerator.hpp
@@ -65,6 +65,36 @@ private:
 };
 
 /**
+ * @brief Hidden grotto multi item generator for Gen 5
+ */
+class HiddenGrottoItemGenerator
+{
+public:
+    /**
+     * @brief Construct a new HiddenGrottoItemGenerator object
+     *
+     * @param generator Hidden grotto slot generator
+     * @param item Item to search for
+     * @param amount Minimum number of items
+     */
+    HiddenGrottoItemGenerator(const HiddenGrottoSlotGenerator &generator, u16 item, u8 amount);
+
+    /**
+     * @brief Generates states
+     *
+     * @param seed Starting PRNG state
+     *
+     * @return Vector of computed states
+     */
+    std::vector<HiddenGrottoState> generate(u64 seed) const;
+
+private:
+    HiddenGrottoSlotGenerator generator;
+    u16 item;
+    u8 amount;
+};
+
+/**
  * @brief Hidden grotto pokemon generator for Gen 5
  */
 class HiddenGrottoGenerator : public Generator<Profile5, StateFilter>

--- a/Core/Gen5/HiddenGrottoArea.cpp
+++ b/Core/Gen5/HiddenGrottoArea.cpp
@@ -18,8 +18,43 @@
  */
 
 #include "HiddenGrottoArea.hpp"
+#include <Core/Enum/Game.hpp>
+#include <Core/Parents/PersonalLoader.hpp>
+#include <Core/Parents/PersonalInfo.hpp>
 #include <Core/Util/Translator.hpp>
 #include <algorithm>
+
+namespace
+{
+    constexpr u8 pinwheelForestExterior = 8;
+    constexpr u8 pinwheelForestInterior = 9;
+    constexpr u8 lostlornForest = 126;
+    constexpr u8 route6Cave = 135;
+
+    constexpr u16 butterfree = 12;
+    constexpr u16 beedrill = 15;
+    constexpr u16 nosepass = 299;
+    constexpr u16 pinsir = 127;
+    constexpr u16 heracross = 214;
+    constexpr u16 hariyama = 297;
+    constexpr u16 medicham = 308;
+
+    bool isBlack2(Game version)
+    {
+        return version == Game::Black2;
+    }
+
+    HiddenGrottoSlot replaceSpecie(const HiddenGrottoSlot &slot, u16 specie)
+    {
+        const PersonalInfo *info = PersonalLoader::getPersonal(Game::BW2);
+        return HiddenGrottoSlot(specie, slot.getGender(), slot.getMinLevel(), slot.getMaxLevel(), &info[specie]);
+    }
+
+    HiddenGrottoSlot replaceGender(const HiddenGrottoSlot &slot, u8 gender)
+    {
+        return HiddenGrottoSlot(slot.getSpecie(), gender, slot.getMinLevel(), slot.getMaxLevel(), slot.getInfo());
+    }
+}
 
 HiddenGrottoArea::HiddenGrottoArea(u8 location, const std::array<HiddenGrottoSlot, 12> &pokemon, const std::array<u16, 16> &item,
                                    const std::array<u16, 16> &hiddenItem) :
@@ -52,9 +87,58 @@ HiddenGrottoSlot HiddenGrottoArea::getPokemon(u8 group, u8 index) const
     return pokemon[group * 3 + index];
 }
 
+HiddenGrottoSlot HiddenGrottoArea::getPokemon(u8 group, u8 index, Game version) const
+{
+    HiddenGrottoSlot slot = getPokemon(group, index);
+    if (!isBlack2(version))
+    {
+        if (version == Game::White2 && location == route6Cave && slot.getSpecie() == nosepass)
+        {
+            return replaceGender(slot, 0);
+        }
+
+        return slot;
+    }
+
+    u16 specie = slot.getSpecie();
+    if (location == pinwheelForestInterior && specie == butterfree)
+    {
+        return replaceSpecie(slot, beedrill);
+    }
+    if (location == lostlornForest)
+    {
+        if (specie == heracross)
+        {
+            return replaceSpecie(slot, pinsir);
+        }
+        if (specie == pinsir)
+        {
+            return replaceSpecie(slot, heracross);
+        }
+    }
+    if (location == pinwheelForestExterior)
+    {
+        if (specie == hariyama)
+        {
+            return replaceSpecie(slot, medicham);
+        }
+        if (specie == medicham)
+        {
+            return replaceSpecie(slot, hariyama);
+        }
+    }
+
+    return slot;
+}
+
 std::vector<std::string> HiddenGrottoArea::getSpecieNames() const
 {
     return Translator::getSpecies(getUniqueSpecies());
+}
+
+std::vector<std::string> HiddenGrottoArea::getSpecieNames(Game version) const
+{
+    return Translator::getSpecies(getUniqueSpecies(version));
 }
 
 std::vector<u16> HiddenGrottoArea::getUniqueItems() const
@@ -87,6 +171,23 @@ std::vector<u16> HiddenGrottoArea::getUniqueSpecies() const
         if (std::ranges::find(nums, mon.getSpecie()) == nums.end())
         {
             nums.emplace_back(mon.getSpecie());
+        }
+    }
+    return nums;
+}
+
+std::vector<u16> HiddenGrottoArea::getUniqueSpecies(Game version) const
+{
+    std::vector<u16> nums;
+    for (u8 group = 0; group < 4; group++)
+    {
+        for (u8 slot = 0; slot < 3; slot++)
+        {
+            HiddenGrottoSlot mon = getPokemon(group, slot, version);
+            if (std::ranges::find(nums, mon.getSpecie()) == nums.end())
+            {
+                nums.emplace_back(mon.getSpecie());
+            }
         }
     }
     return nums;

--- a/Core/Gen5/HiddenGrottoArea.hpp
+++ b/Core/Gen5/HiddenGrottoArea.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 class PersonalInfo;
+enum class Game : u32;
 
 /**
  * @brief Contains information that impact the generation of hidden grotto encounters
@@ -172,11 +173,31 @@ public:
     HiddenGrottoSlot getPokemon(u8 group, u8 index) const;
 
     /**
+     * @brief Returns the pokemon at the \p group and \p index for the selected game version
+     *
+     * @param group Pokemon group
+     * @param index Pokemon index
+     * @param version Game version
+     *
+     * @return Pokemon
+     */
+    HiddenGrottoSlot getPokemon(u8 group, u8 index, Game version) const;
+
+    /**
      * @brief Return vector of names of all pokemon slots
      *
      * @return Vector of pokemon name
      */
     std::vector<std::string> getSpecieNames() const;
+
+    /**
+     * @brief Return vector of names of all pokemon slots for the selected game version
+     *
+     * @param version Game version
+     *
+     * @return Vector of pokemon name
+     */
+    std::vector<std::string> getSpecieNames(Game version) const;
 
     /**
      * @brief Return the item numbers of unique item of the area
@@ -191,6 +212,15 @@ public:
      * @return Vector of pokemon species
      */
     std::vector<u16> getUniqueSpecies() const;
+
+    /**
+     * @brief Return the species numbers of unique pokemon of the area for the selected game version
+     *
+     * @param version Game version
+     *
+     * @return Vector of pokemon species
+     */
+    std::vector<u16> getUniqueSpecies(Game version) const;
 
 private:
     std::array<HiddenGrottoSlot, 12> pokemon;

--- a/Core/Gen5/States/HiddenGrottoState.hpp
+++ b/Core/Gen5/States/HiddenGrottoState.hpp
@@ -21,6 +21,7 @@
 #define HIDDENGROTTOSTATE_HPP
 
 #include <Core/Global.hpp>
+#include <vector>
 
 /**
  * @brief State class for Gen5 hidden grottos
@@ -40,8 +41,10 @@ public:
      */
     HiddenGrottoState(u32 prng, u32 advances, u8 group, u8 slot, u16 specie, u8 gender) :
         advances(advances),
+        itemAdvances(),
         data(specie),
         item(false),
+        amount(1),
         chatot(static_cast<u8>(((static_cast<u64>(prng) * 0x1fff) >> 32) / 82)),
         gender(gender),
         group(group),
@@ -61,8 +64,10 @@ public:
      */
     HiddenGrottoState(u32 prng, u32 advances, u8 group, u8 slot, u16 item) :
         advances(advances),
+        itemAdvances(),
         data(item),
         item(true),
+        amount(1),
         chatot(static_cast<u8>(((static_cast<u64>(prng) * 0x1fff) >> 32) / 82)),
         gender(0),
         group(group),
@@ -79,6 +84,16 @@ public:
     u32 getAdvances() const
     {
         return advances;
+    }
+
+    /**
+     * @brief Returns the number of matching items represented by this state
+     *
+     * @return Matching item amount
+     */
+    u16 getAmount() const
+    {
+        return amount;
     }
 
     /**
@@ -134,6 +149,16 @@ public:
     }
 
     /**
+     * @brief Returns each matching item advance represented by this state
+     *
+     * @return Matching item advances
+     */
+    const std::vector<u32> &getItemAdvances() const
+    {
+        return itemAdvances;
+    }
+
+    /**
      * @brief Returns the needle value
      *
      * @return Needle value
@@ -153,10 +178,23 @@ public:
         return slot;
     }
 
+    /**
+     * @brief Sets the matching item advances represented by this state
+     *
+     * @param itemAdvances Matching item advances
+     */
+    void setItemAdvances(const std::vector<u32> &itemAdvances)
+    {
+        this->itemAdvances = itemAdvances;
+        amount = static_cast<u16>(itemAdvances.size());
+    }
+
 private:
     u32 advances;
+    std::vector<u32> itemAdvances;
     u16 data;
     bool item;
+    u16 amount;
     u8 chatot;
     u8 gender;
     u8 group;

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -46,11 +46,72 @@
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
+#include <algorithm>
 
 static const QString settingPrefix = QStringLiteral("hiddenGrotto");
 
+static std::vector<std::pair<u8, QString>> getSortedPokemonSlots(const HiddenGrottoArea &area, Game version)
+{
+    std::vector<std::pair<u8, QString>> pokemonSlots;
+    std::vector<u16> species;
+    for (u8 group = 0; group < 4; group++)
+    {
+        for (u8 slot = 0; slot < 3; slot++)
+        {
+            auto pokemon = area.getPokemon(group, slot, version);
+            u16 specie = pokemon.getSpecie();
+            if (std::ranges::find(species, specie) == species.end())
+            {
+                species.emplace_back(specie);
+                pokemonSlots.emplace_back(group * 3 + slot, QString::fromStdString(Translator::getSpecie(specie)));
+            }
+        }
+    }
+
+    std::ranges::sort(pokemonSlots, [](const auto &left, const auto &right) {
+        return QString::localeAwareCompare(left.second, right.second) < 0;
+    });
+
+    return pokemonSlots;
+}
+
+static HiddenGrottoSlot getPokemonSlot(const HiddenGrottoArea &area, u8 slot, Game version)
+{
+    return area.getPokemon(slot / 3, slot % 3, version);
+}
+
+static void updatePokemonList(ComboBox *comboBox, const HiddenGrottoArea &area, Game version)
+{
+    comboBox->clear();
+    for (const auto &[slot, name] : getSortedPokemonSlots(area, version))
+    {
+        comboBox->addItem(name, slot);
+    }
+}
+
+static void updateSpeciesList(ComboBox *comboBox, const HiddenGrottoArea &area, Game version)
+{
+    std::vector<std::pair<u16, QString>> species;
+    for (u16 specie : area.getUniqueSpecies(version))
+    {
+        species.emplace_back(specie, QString::fromStdString(Translator::getSpecie(specie)));
+    }
+
+    std::ranges::sort(species, [](const auto &left, const auto &right) {
+        return QString::localeAwareCompare(left.second, right.second) < 0;
+    });
+
+    comboBox->clear();
+    comboBox->addItem("-");
+    for (const auto &[specie, name] : species)
+    {
+        comboBox->addItem(name, specie);
+    }
+}
+
 HiddenGrotto::HiddenGrotto(QWidget *parent) :
-    QWidget(parent), ui(new Ui::HiddenGrotto), ivCache(nullptr), shaCache(nullptr), encounter(Encounters5::getHiddenGrottoEncounters())
+    QWidget(parent), ui(new Ui::HiddenGrotto), ivCache(nullptr), currentProfile(nullptr), shaCache(nullptr),
+    encounter(Encounters5::getHiddenGrottoEncounters())
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_QuitOnClose, false);
@@ -157,8 +218,6 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
             ui->spinBoxGrottoSearcherItemAmount->setValue(1);
         }
     });
-    connect(ui->comboBoxPokemonGeneratorGroup, &QComboBox::currentIndexChanged, this, &HiddenGrotto::pokemonGeneratorGroupIndexChanged);
-    connect(ui->comboBoxPokemonSearcherGroup, &QComboBox::currentIndexChanged, this, &HiddenGrotto::pokemonSearcherGroupIndexChanged);
     connect(ui->comboBoxPokemonGeneratorLocation, &QComboBox::currentIndexChanged, this,
             &HiddenGrotto::pokemonGeneratorLocationIndexChanged);
     connect(ui->comboBoxPokemonSearcherLocation, &QComboBox::currentIndexChanged, this, &HiddenGrotto::pokemonSearcherLocationIndexChanged);
@@ -287,15 +346,8 @@ void HiddenGrotto::grottoGeneratorLocationIndexChanged(int index)
     if (index >= 0)
     {
         auto &area = encounter[ui->comboBoxGrottoGeneratorLocation->currentIndex()];
-        auto pokemon = area.getUniqueSpecies();
-        auto pokemonNames = area.getSpecieNames();
-
-        ui->comboBoxGrottoGeneratorPokemon->clear();
-        ui->comboBoxGrottoGeneratorPokemon->addItem("-");
-        for (int i = 0; i < pokemon.size(); i++)
-        {
-            ui->comboBoxGrottoGeneratorPokemon->addItem(QString::fromStdString(pokemonNames[i]), pokemon[i]);
-        }
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        updateSpeciesList(ui->comboBoxGrottoGeneratorPokemon, area, version);
 
         auto item = area.getUniqueItems();
         auto itemNames = area.getItemNames();
@@ -315,6 +367,7 @@ void HiddenGrotto::grottoGeneratorUpdateFilter()
     std::vector<bool> encounterSlots(11, false);
 
     const auto &area = encounter[ui->comboBoxGrottoGeneratorLocation->currentIndex()];
+    Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
     u16 specie = ui->comboBoxGrottoGeneratorPokemon->getCurrentUShort();
     u16 item = ui->comboBoxGrottoGeneratorItems->getCurrentUShort();
 
@@ -323,7 +376,7 @@ void HiddenGrotto::grottoGeneratorUpdateFilter()
         u8 slot = 0;
         for (; slot < 3; slot++)
         {
-            if (specie != 0 && specie == area.getPokemon(group, slot).getSpecie())
+            if (specie != 0 && specie == area.getPokemon(group, slot, version).getSpecie())
             {
                 groups[group] = true;
                 encounterSlots[slot] = true;
@@ -432,15 +485,8 @@ void HiddenGrotto::grottoSearcherLocationIndexChanged(int index)
     {
         const auto &area = encounter[ui->comboBoxGrottoSearcherLocation->currentIndex()];
 
-        std::vector<u16> pokemon = area.getUniqueSpecies();
-        std::vector<std::string> pokemonNames = area.getSpecieNames();
-
-        ui->comboBoxGrottoSearcherPokemon->clear();
-        ui->comboBoxGrottoSearcherPokemon->addItem("-");
-        for (int i = 0; i < pokemon.size(); i++)
-        {
-            ui->comboBoxGrottoSearcherPokemon->addItem(QString::fromStdString(pokemonNames[i]), pokemon[i]);
-        }
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        updateSpeciesList(ui->comboBoxGrottoSearcherPokemon, area, version);
 
         std::vector<u16> item = area.getUniqueItems();
         std::vector<std::string> itemNames = area.getItemNames();
@@ -461,15 +507,17 @@ void HiddenGrotto::grottoSearcherUpdateFilter()
     std::vector<bool> encounterSlots(11, false);
 
     const auto &area = encounter[ui->comboBoxGrottoSearcherLocation->currentIndex()];
-    u16 specie = ui->radioButtonGrottoSearcherPokemon->isChecked() ? ui->comboBoxGrottoSearcherPokemon->getCurrentUShort() : 0;
-    u16 item = ui->radioButtonGrottoSearcherItems->isChecked() ? ui->comboBoxGrottoSearcherItems->getCurrentUShort() : 0;
+    Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+    bool itemTarget = ui->radioButtonGrottoSearcherItems->isChecked();
+    u16 specie = itemTarget ? 0 : ui->comboBoxGrottoSearcherPokemon->getCurrentUShort();
+    u16 item = itemTarget ? ui->comboBoxGrottoSearcherItems->getCurrentUShort() : 0;
 
     for (u8 group = 0; group < 4; group++)
     {
         u8 slot = 0;
         for (; slot < 3; slot++)
         {
-            if (specie != 0 && specie == area.getPokemon(group, slot).getSpecie())
+            if (specie != 0 && specie == area.getPokemon(group, slot, version).getSpecie())
             {
                 groups[group] = true;
                 encounterSlots[slot] = true;
@@ -537,8 +585,8 @@ void HiddenGrotto::pokemonGenerate()
     auto lead = ui->comboMenuPokemonGeneratorLead->getEnum<Lead>();
     u8 gender = ui->comboBoxPokemonGeneratorGender->getCurrentUChar();
 
-    auto slot = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()].getPokemon(
-        ui->comboBoxPokemonGeneratorGroup->currentIndex(), ui->comboBoxPokemonGeneratorPokemon->currentIndex());
+    const auto &area = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()];
+    auto slot = getPokemonSlot(area, ui->comboBoxPokemonGeneratorPokemon->getCurrentUChar(), currentProfile->getVersion());
 
     auto filter = ui->filterPokemonGenerator->getFilter<StateFilter>();
     HiddenGrottoGenerator generator(initialAdvances, maxAdvances, offset, lead, gender, slot, *currentProfile, filter);
@@ -547,27 +595,12 @@ void HiddenGrotto::pokemonGenerate()
     pokemonGeneratorModel->addItems(states);
 }
 
-void HiddenGrotto::pokemonGeneratorGroupIndexChanged(int index)
-{
-    if (index >= 0)
-    {
-        auto &area = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()];
-
-        ui->comboBoxPokemonGeneratorPokemon->clear();
-        for (int i = 0; i < 3; i++)
-        {
-            auto pokemon = area.getPokemon(index, i);
-            ui->comboBoxPokemonGeneratorPokemon->addItem(
-                QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
-        }
-    }
-}
-
 void HiddenGrotto::pokemonGeneratorLocationIndexChanged(int index)
 {
     if (index >= 0)
     {
-        pokemonGeneratorGroupIndexChanged(ui->comboBoxPokemonGeneratorGroup->currentIndex());
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        updatePokemonList(ui->comboBoxPokemonGeneratorPokemon, encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()], version);
     }
 }
 
@@ -575,9 +608,9 @@ void HiddenGrotto::pokemonGeneratorPokemonIndexChanged(int index)
 {
     if (index >= 0)
     {
-        auto &area = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()];
-        auto pokemon
-            = area.getPokemon(ui->comboBoxPokemonGeneratorGroup->currentIndex(), ui->comboBoxPokemonGeneratorPokemon->currentIndex());
+        const auto &area = encounter[ui->comboBoxPokemonGeneratorLocation->currentIndex()];
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        auto pokemon = getPokemonSlot(area, ui->comboBoxPokemonGeneratorPokemon->getCurrentUChar(), version);
 
         ui->comboBoxPokemonGeneratorGender->clear();
         switch (pokemon.getInfo()->getGender())
@@ -631,8 +664,8 @@ void HiddenGrotto::pokemonSearch()
     auto lead = ui->comboMenuPokemonSearcherLead->getEnum<Lead>();
     u8 gender = ui->comboBoxPokemonSearcherGender->getCurrentUChar();
 
-    auto slot = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()].getPokemon(
-        ui->comboBoxPokemonSearcherGroup->currentIndex(), ui->comboBoxPokemonSearcherPokemon->currentIndex());
+    const auto &area = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()];
+    auto slot = getPokemonSlot(area, ui->comboBoxPokemonSearcherPokemon->getCurrentUChar(), currentProfile->getVersion());
 
     auto filter = ui->filterPokemonSearcher->getFilter<StateFilter>();
     HiddenGrottoGenerator generator(initialAdvances, maxAdvances, 0, lead, gender, slot, *currentProfile, filter);
@@ -717,27 +750,12 @@ void HiddenGrotto::pokemonSearcherFastSearchChanged()
     }
 }
 
-void HiddenGrotto::pokemonSearcherGroupIndexChanged(int index)
-{
-    if (index >= 0)
-    {
-        auto &area = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()];
-
-        ui->comboBoxPokemonSearcherPokemon->clear();
-        for (int i = 0; i < 3; i++)
-        {
-            auto pokemon = area.getPokemon(index, i);
-            ui->comboBoxPokemonSearcherPokemon->addItem(
-                QString("%1: %2").arg(i).arg(QString::fromStdString(Translator::getSpecie(pokemon.getSpecie()))), pokemon.getSpecie());
-        }
-    }
-}
-
 void HiddenGrotto::pokemonSearcherLocationIndexChanged(int index)
 {
     if (index >= 0)
     {
-        pokemonSearcherGroupIndexChanged(ui->comboBoxPokemonSearcherGroup->currentIndex());
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        updatePokemonList(ui->comboBoxPokemonSearcherPokemon, encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()], version);
     }
 }
 
@@ -745,9 +763,9 @@ void HiddenGrotto::pokemonSearcherPokemonIndexChanged(int index)
 {
     if (index >= 0)
     {
-        auto &area = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()];
-        auto pokemon
-            = area.getPokemon(ui->comboBoxPokemonSearcherGroup->currentIndex(), ui->comboBoxPokemonSearcherPokemon->currentIndex());
+        const auto &area = encounter[ui->comboBoxPokemonSearcherLocation->currentIndex()];
+        Game version = currentProfile != nullptr ? currentProfile->getVersion() : Game::White2;
+        auto pokemon = getPokemonSlot(area, ui->comboBoxPokemonSearcherPokemon->getCurrentUChar(), version);
 
         ui->comboBoxPokemonSearcherGender->clear();
         switch (pokemon.getInfo()->getGender())
@@ -808,6 +826,10 @@ void HiddenGrotto::profileChanged(const Profile5 &profile)
         ui->dateEditPokemonSearcherEndDate->clearDateRange();
     }
 
+    grottoGeneratorLocationIndexChanged(ui->comboBoxGrottoGeneratorLocation->currentIndex());
+    grottoSearcherLocationIndexChanged(ui->comboBoxGrottoSearcherLocation->currentIndex());
+    pokemonGeneratorLocationIndexChanged(ui->comboBoxPokemonGeneratorLocation->currentIndex());
+    pokemonSearcherLocationIndexChanged(ui->comboBoxPokemonSearcherLocation->currentIndex());
     pokemonSearcherFastSearchChanged();
 }
 
@@ -869,14 +891,12 @@ void HiddenGrotto::transferSettingsPokemon(int index)
     if (index == 0)
     {
         ui->comboBoxPokemonSearcherLocation->setCurrentIndex(ui->comboBoxPokemonGeneratorLocation->currentIndex());
-        ui->comboBoxPokemonSearcherGroup->setCurrentIndex(ui->comboBoxPokemonGeneratorGroup->currentIndex());
         ui->comboBoxPokemonSearcherPokemon->setCurrentIndex(ui->comboBoxPokemonGeneratorPokemon->currentIndex());
         ui->comboBoxPokemonSearcherGender->setCurrentIndex(ui->comboBoxPokemonGeneratorGender->currentIndex());
     }
     else
     {
         ui->comboBoxPokemonGeneratorLocation->setCurrentIndex(ui->comboBoxPokemonSearcherLocation->currentIndex());
-        ui->comboBoxPokemonGeneratorGroup->setCurrentIndex(ui->comboBoxPokemonSearcherGroup->currentIndex());
         ui->comboBoxPokemonGeneratorPokemon->setCurrentIndex(ui->comboBoxPokemonSearcherPokemon->currentIndex());
         ui->comboBoxPokemonGeneratorGender->setCurrentIndex(ui->comboBoxPokemonSearcherGender->currentIndex());
     }

--- a/Form/Gen5/HiddenGrotto.cpp
+++ b/Form/Gen5/HiddenGrotto.cpp
@@ -42,6 +42,7 @@
 #include <QAction>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QRadioButton>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
@@ -61,7 +62,9 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
 
     grottoSearcherModel = new HiddenGrottoSlotSearcherModel5(ui->tableViewGrottoSearcher);
     grottoProxyModel = new SortFilterProxyModel(ui->tableViewGrottoSearcher, grottoSearcherModel);
+    grottoProxyModel->setSortRole(Qt::UserRole);
     ui->tableViewGrottoSearcher->setModel(grottoProxyModel);
+    ui->tableViewGrottoSearcher->setColumnHidden(4, true);
 
     ui->textBoxGrottoGeneratorSeed->setValues(InputType::Seed64Bit);
     ui->textBoxGrottoGeneratorInitialAdvances->setValues(InputType::Advance32Bit);
@@ -131,6 +134,29 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
     connect(ui->comboBoxGrottoSearcherPokemon, &QComboBox::currentIndexChanged, this, &HiddenGrotto::grottoSearcherUpdateFilter);
     connect(ui->comboBoxGrottoGeneratorItems, &QComboBox::currentIndexChanged, this, &HiddenGrotto::grottoGeneratorUpdateFilter);
     connect(ui->comboBoxGrottoSearcherItems, &QComboBox::currentIndexChanged, this, &HiddenGrotto::grottoSearcherUpdateFilter);
+    connect(ui->radioButtonGrottoSearcherPokemon, &QRadioButton::toggled, this, [=] {
+        bool itemTarget = ui->radioButtonGrottoSearcherItems->isChecked();
+        ui->comboBoxGrottoSearcherPokemon->setEnabled(!itemTarget);
+        ui->comboBoxGrottoSearcherItems->setEnabled(itemTarget);
+        ui->spinBoxGrottoSearcherItemAmount->setEnabled(itemTarget);
+        ui->tableViewGrottoSearcher->setColumnHidden(4, !itemTarget);
+        if (itemTarget)
+        {
+            ui->comboBoxGrottoSearcherPokemon->setCurrentIndex(0);
+        }
+        else
+        {
+            ui->comboBoxGrottoSearcherItems->setCurrentIndex(0);
+            ui->spinBoxGrottoSearcherItemAmount->setValue(1);
+        }
+        grottoSearcherUpdateFilter();
+    });
+    connect(ui->comboBoxGrottoSearcherItems, &QComboBox::currentIndexChanged, this, [=] {
+        if (ui->comboBoxGrottoSearcherItems->currentIndex() == 0)
+        {
+            ui->spinBoxGrottoSearcherItemAmount->setValue(1);
+        }
+    });
     connect(ui->comboBoxPokemonGeneratorGroup, &QComboBox::currentIndexChanged, this, &HiddenGrotto::pokemonGeneratorGroupIndexChanged);
     connect(ui->comboBoxPokemonSearcherGroup, &QComboBox::currentIndexChanged, this, &HiddenGrotto::pokemonSearcherGroupIndexChanged);
     connect(ui->comboBoxPokemonGeneratorLocation, &QComboBox::currentIndexChanged, this,
@@ -160,6 +186,8 @@ HiddenGrotto::HiddenGrotto(QWidget *parent) :
 
     updateProfiles();
     pokemonSearcherFastSearchChanged();
+    ui->comboBoxGrottoSearcherItems->setEnabled(false);
+    ui->spinBoxGrottoSearcherItemAmount->setEnabled(false);
 
     QSettings setting;
     setting.beginGroup(settingPrefix);
@@ -343,44 +371,59 @@ void HiddenGrotto::grottoSearch()
     u32 initialAdvances = ui->textBoxGrottoSearcherInitialAdvances->getUInt();
     u32 maxAdvances = ui->textBoxGrottoSearcherMaxAdvances->getUInt();
     u8 powerLevel = ui->comboBoxGrottoSearcherGrottoPower->getCurrentUInt();
+    bool itemTarget = ui->radioButtonGrottoSearcherItems->isChecked();
+    u16 item = itemTarget ? ui->comboBoxGrottoSearcherItems->getCurrentUShort() : 0;
+    u8 itemAmount = itemTarget ? static_cast<u8>(ui->spinBoxGrottoSearcherItemAmount->value()) : 1;
 
     HiddenGrottoFilter filter(ui->checkListGrottoSearcherSlot->getCheckedArray<11>(),
                               ui->checkListGrottoSearcherGender->getCheckedArray<2>(),
                               ui->checkListGrottoSearcherGroup->getCheckedArray<4>());
     HiddenGrottoSlotGenerator generator(initialAdvances, maxAdvances, 0, powerLevel,
                                         encounter[ui->comboBoxGrottoSearcherLocation->currentIndex()], *currentProfile, filter);
-    auto *searcher = new Searcher5<HiddenGrottoSlotGenerator, HiddenGrottoState>(generator, *currentProfile);
 
-    int maxProgress = Keypresses::getKeypresses(*currentProfile).size();
-    maxProgress *= start.daysTo(end) + 1;
-    maxProgress *= currentProfile->getTimer0Max() - currentProfile->getTimer0Min() + 1;
-    searcher->setMaxProgress(maxProgress);
+    auto search = [=]<typename Generator>(const Generator &generator) {
+        auto *searcher = new Searcher5<Generator, HiddenGrottoState>(generator, *currentProfile);
 
-    QSettings settings;
-    int threads = settings.value("settings/threads").toInt();
+        int maxProgress = Keypresses::getKeypresses(*currentProfile).size();
+        maxProgress *= start.daysTo(end) + 1;
+        maxProgress *= currentProfile->getTimer0Max() - currentProfile->getTimer0Min() + 1;
+        searcher->setMaxProgress(maxProgress);
 
-    auto *thread = QThread::create([=] { searcher->startSearch(threads, start, end); });
-    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
-    connect(ui->pushButtonGrottoCancel, &QPushButton::clicked, [searcher] { searcher->cancelSearch(); });
+        QSettings settings;
+        int threads = settings.value("settings/threads").toInt();
 
-    auto *timer = new QTimer();
-    connect(timer, &QTimer::timeout, this, [=] {
-        grottoSearcherModel->addItems(searcher->getResults());
-        ui->progressBarGrotto->setValue(searcher->getProgress());
-    });
+        auto *thread = QThread::create([=] { searcher->startSearch(threads, start, end); });
+        connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+        connect(ui->pushButtonGrottoCancel, &QPushButton::clicked, [searcher] { searcher->cancelSearch(); });
 
-    connect(thread, &QThread::finished, timer, &QTimer::stop);
-    connect(thread, &QThread::finished, timer, &QTimer::deleteLater);
-    connect(timer, &QTimer::destroyed, this, [=] {
-        ui->pushButtonGrottoSearch->setEnabled(true);
-        ui->pushButtonGrottoCancel->setEnabled(false);
-        grottoSearcherModel->addItems(searcher->getResults());
-        ui->progressBarGrotto->setValue(searcher->getProgress());
-        delete searcher;
-    });
+        auto *timer = new QTimer();
+        connect(timer, &QTimer::timeout, this, [=] {
+            grottoSearcherModel->addItems(searcher->getResults());
+            ui->progressBarGrotto->setValue(searcher->getProgress());
+        });
 
-    thread->start();
-    timer->start(1000);
+        connect(thread, &QThread::finished, timer, &QTimer::stop);
+        connect(thread, &QThread::finished, timer, &QTimer::deleteLater);
+        connect(timer, &QTimer::destroyed, this, [=] {
+            ui->pushButtonGrottoSearch->setEnabled(true);
+            ui->pushButtonGrottoCancel->setEnabled(false);
+            grottoSearcherModel->addItems(searcher->getResults());
+            ui->progressBarGrotto->setValue(searcher->getProgress());
+            delete searcher;
+        });
+
+        thread->start();
+        timer->start(1000);
+    };
+
+    if (item != 0 && itemAmount > 1)
+    {
+        search(HiddenGrottoItemGenerator(generator, item, itemAmount));
+    }
+    else
+    {
+        search(generator);
+    }
 }
 
 void HiddenGrotto::grottoSearcherLocationIndexChanged(int index)
@@ -408,6 +451,7 @@ void HiddenGrotto::grottoSearcherLocationIndexChanged(int index)
         {
             ui->comboBoxGrottoSearcherItems->addItem(QString::fromStdString(itemNames[i]), item[i]);
         }
+        ui->spinBoxGrottoSearcherItemAmount->setValue(1);
     }
 }
 
@@ -417,8 +461,8 @@ void HiddenGrotto::grottoSearcherUpdateFilter()
     std::vector<bool> encounterSlots(11, false);
 
     const auto &area = encounter[ui->comboBoxGrottoSearcherLocation->currentIndex()];
-    u16 specie = ui->comboBoxGrottoSearcherPokemon->getCurrentUShort();
-    u16 item = ui->comboBoxGrottoSearcherItems->getCurrentUShort();
+    u16 specie = ui->radioButtonGrottoSearcherPokemon->isChecked() ? ui->comboBoxGrottoSearcherPokemon->getCurrentUShort() : 0;
+    u16 item = ui->radioButtonGrottoSearcherItems->isChecked() ? ui->comboBoxGrottoSearcherItems->getCurrentUShort() : 0;
 
     for (u8 group = 0; group < 4; group++)
     {
@@ -788,8 +832,17 @@ void HiddenGrotto::transferSettingsGrotto(int index)
     if (index == 0)
     {
         ui->comboBoxGrottoSearcherLocation->setCurrentIndex(ui->comboBoxGrottoGeneratorLocation->currentIndex());
-        ui->comboBoxGrottoSearcherPokemon->setCurrentIndex(ui->comboBoxGrottoGeneratorPokemon->currentIndex());
-        ui->comboBoxGrottoSearcherItems->setCurrentIndex(ui->comboBoxGrottoGeneratorItems->currentIndex());
+        if (ui->comboBoxGrottoGeneratorItems->currentIndex() > 0)
+        {
+            ui->radioButtonGrottoSearcherItems->setChecked(true);
+            ui->comboBoxGrottoSearcherItems->setCurrentIndex(ui->comboBoxGrottoGeneratorItems->currentIndex());
+        }
+        else
+        {
+            ui->radioButtonGrottoSearcherPokemon->setChecked(true);
+            ui->comboBoxGrottoSearcherPokemon->setCurrentIndex(ui->comboBoxGrottoGeneratorPokemon->currentIndex());
+        }
+        ui->spinBoxGrottoSearcherItemAmount->setValue(1);
     }
     else
     {

--- a/Form/Gen5/HiddenGrotto.hpp
+++ b/Form/Gen5/HiddenGrotto.hpp
@@ -154,13 +154,6 @@ private slots:
     void pokemonGenerate();
 
     /**
-     * @brief Updates the group listed
-     *
-     * @param index Group index
-     */
-    void pokemonGeneratorGroupIndexChanged(int index);
-
-    /**
      * @brief Updates the grotto listed
      *
      * @param index Location index
@@ -183,13 +176,6 @@ private slots:
      * @brief Updates fast search eligibility based on IV advances and IV filters.
      */
     void pokemonSearcherFastSearchChanged();
-
-    /**
-     * @brief Updates the group listed
-     *
-     * @param index Group index
-     */
-    void pokemonSearcherGroupIndexChanged(int index);
 
     /**
      * @brief Updates the grotto listed

--- a/Form/Gen5/HiddenGrotto.ui
+++ b/Form/Gen5/HiddenGrotto.ui
@@ -469,9 +469,12 @@
                <widget class="ComboBoxProxy" name="comboBoxGrottoSearcherLocation"/>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="labelGrottoSearcherPokemon">
+               <widget class="QRadioButton" name="radioButtonGrottoSearcherPokemon">
                 <property name="text">
                  <string>Pokemon</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -479,7 +482,7 @@
                <widget class="ComboBox" name="comboBoxGrottoSearcherPokemon"/>
               </item>
               <item row="2" column="0">
-               <widget class="QLabel" name="labelGrottoSearcherItems">
+               <widget class="QRadioButton" name="radioButtonGrottoSearcherItems">
                 <property name="text">
                  <string>Items</string>
                 </property>
@@ -487,6 +490,25 @@
               </item>
               <item row="2" column="1">
                <widget class="ComboBox" name="comboBoxGrottoSearcherItems"/>
+              </item>
+              <item row="2" column="2">
+               <widget class="QSpinBox" name="spinBoxGrottoSearcherItemAmount">
+                <property name="maximumSize">
+                 <size>
+                  <width>55</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>99</number>
+                </property>
+                <property name="value">
+                 <number>1</number>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -1233,8 +1255,11 @@
   <tabstop>pushButtonGrottoSearch</tabstop>
   <tabstop>pushButtonGrottoCancel</tabstop>
   <tabstop>comboBoxGrottoSearcherLocation</tabstop>
+  <tabstop>radioButtonGrottoSearcherPokemon</tabstop>
   <tabstop>comboBoxGrottoSearcherPokemon</tabstop>
+  <tabstop>radioButtonGrottoSearcherItems</tabstop>
   <tabstop>comboBoxGrottoSearcherItems</tabstop>
+  <tabstop>spinBoxGrottoSearcherItemAmount</tabstop>
   <tabstop>checkListGrottoSearcherSlot</tabstop>
   <tabstop>checkListGrottoSearcherGroup</tabstop>
   <tabstop>checkListGrottoSearcherGender</tabstop>

--- a/Form/Gen5/HiddenGrotto.ui
+++ b/Form/Gen5/HiddenGrotto.ui
@@ -791,64 +791,33 @@
                <widget class="ComboBoxProxy" name="comboBoxPokemonGeneratorLocation"/>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="labelPokemonGeneratorGroup">
-                <property name="text">
-                 <string>Group</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxPokemonGeneratorGroup">
-                <item>
-                 <property name="text">
-                  <string notr="true">0</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">1</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">2</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">3</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="2" column="0">
                <widget class="QLabel" name="labelPokemonGeneratorPokemon">
                 <property name="text">
                  <string>Pokemon</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="2">
+              <item row="1" column="1" colspan="2">
                <widget class="ComboBox" name="comboBoxPokemonGeneratorPokemon"/>
               </item>
-              <item row="3" column="0">
+              <item row="2" column="0">
                <widget class="QLabel" name="labelPokemonGeneratorGender">
                 <property name="text">
                  <string>Gender</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="1" colspan="2">
+              <item row="2" column="1" colspan="2">
                <widget class="ComboBox" name="comboBoxPokemonGeneratorGender"/>
               </item>
-              <item row="4" column="0">
+              <item row="3" column="0">
                <widget class="QLabel" name="labelPokemonGeneratorLevel">
                 <property name="text">
                  <string>Levels</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
+              <item row="3" column="1">
                <widget class="QSpinBox" name="spinBoxPokemonGeneratorLevelMin">
                 <property name="enabled">
                  <bool>false</bool>
@@ -858,7 +827,7 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
+              <item row="3" column="2">
                <widget class="QSpinBox" name="spinBoxPokemonGeneratorLevelMax">
                 <property name="enabled">
                  <bool>false</bool>
@@ -1044,64 +1013,33 @@
                <widget class="ComboBoxProxy" name="comboBoxPokemonSearcherLocation"/>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="labelPokemonSearcherGroup">
-                <property name="text">
-                 <string>Group</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1" colspan="2">
-               <widget class="QComboBox" name="comboBoxPokemonSearcherGroup">
-                <item>
-                 <property name="text">
-                  <string notr="true">0</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">1</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">2</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">3</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="2" column="0">
                <widget class="QLabel" name="labelPokemonSearcherPokemon">
                 <property name="text">
                  <string>Pokemon</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1" colspan="2">
+              <item row="1" column="1" colspan="2">
                <widget class="ComboBox" name="comboBoxPokemonSearcherPokemon"/>
               </item>
-              <item row="3" column="0">
+              <item row="2" column="0">
                <widget class="QLabel" name="labelPokemonSearcherGender">
                 <property name="text">
                  <string>Gender</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="1" colspan="2">
+              <item row="2" column="1" colspan="2">
                <widget class="ComboBox" name="comboBoxPokemonSearcherGender"/>
               </item>
-              <item row="4" column="0">
+              <item row="3" column="0">
                <widget class="QLabel" name="labelPokemonSearcherLevel">
                 <property name="text">
                  <string>Levels</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
+              <item row="3" column="1">
                <widget class="QSpinBox" name="spinBoxPokemonSearcherLevelMin">
                 <property name="enabled">
                  <bool>false</bool>
@@ -1111,7 +1049,7 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
+              <item row="3" column="2">
                <widget class="QSpinBox" name="spinBoxPokemonSearcherLevelMax">
                 <property name="enabled">
                  <bool>false</bool>
@@ -1121,14 +1059,14 @@
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="3">
+              <item row="4" column="0" colspan="3">
                <widget class="Line" name="line">
                 <property name="orientation">
                  <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="3">
+              <item row="5" column="0" colspan="3">
                <widget class="QLabel" name="labelPokemonSearcherIVFastSearch">
                 <property name="text">
                  <string/>
@@ -1273,7 +1211,6 @@
   <tabstop>textBoxPokemonGeneratorOffset</tabstop>
   <tabstop>pushButtonPokemonGenerate</tabstop>
   <tabstop>comboBoxPokemonGeneratorLocation</tabstop>
-  <tabstop>comboBoxPokemonGeneratorGroup</tabstop>
   <tabstop>comboBoxPokemonGeneratorPokemon</tabstop>
   <tabstop>comboBoxPokemonGeneratorGender</tabstop>
   <tabstop>tableViewPokemonGenerator</tabstop>
@@ -1287,7 +1224,6 @@
   <tabstop>pushButtonPokemonSearch</tabstop>
   <tabstop>pushButtonPokemonCancel</tabstop>
   <tabstop>comboBoxPokemonSearcherLocation</tabstop>
-  <tabstop>comboBoxPokemonSearcherGroup</tabstop>
   <tabstop>comboBoxPokemonSearcherPokemon</tabstop>
   <tabstop>comboBoxPokemonSearcherGender</tabstop>
   <tabstop>tableViewPokemonSearcher</tabstop>

--- a/Form/i18n/PokeFinder_de.ts
+++ b/Form/i18n/PokeFinder_de.ts
@@ -3947,6 +3947,11 @@ Profil hat kein oder ein inkompatibles SHA Cache.</translation>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation>Anzahl</translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation>Datum/Uhrzeit</translation>

--- a/Form/i18n/PokeFinder_es.ts
+++ b/Form/i18n/PokeFinder_es.ts
@@ -3947,6 +3947,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Espacio</translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation type="unfinished">Fecha/Hora</translation>

--- a/Form/i18n/PokeFinder_fr.ts
+++ b/Form/i18n/PokeFinder_fr.ts
@@ -3946,6 +3946,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_it.ts
+++ b/Form/i18n/PokeFinder_it.ts
@@ -3947,6 +3947,11 @@ Il profilo è mancante o ha una cache SHA incompatibile.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation>Data/Ora</translation>

--- a/Form/i18n/PokeFinder_ja.ts
+++ b/Form/i18n/PokeFinder_ja.ts
@@ -3946,6 +3946,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_ko.ts
+++ b/Form/i18n/PokeFinder_ko.ts
@@ -3946,6 +3946,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation type="unfinished"></translation>

--- a/Form/i18n/PokeFinder_zh.ts
+++ b/Form/i18n/PokeFinder_zh.ts
@@ -3946,6 +3946,11 @@ Profile is missing or has an incompatible SHA cache.</source>
         <translation type="unfinished">Slot</translation>
     </message>
     <message>
+        <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="143"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Model/Gen5/HiddenGrottoModel.hpp" line="142"/>
         <source>Date/Time</source>
         <translation>日期/时间</translation>

--- a/Model/Gen5/HiddenGrottoModel.cpp
+++ b/Model/Gen5/HiddenGrottoModel.cpp
@@ -21,6 +21,32 @@
 #include <Core/Util/Translator.hpp>
 #include <Core/Util/Utilities.hpp>
 
+namespace
+{
+    bool shouldShowSlotGender(u16 specie)
+    {
+        return specie != 29 && specie != 32 && specie != 132 && specie != 375 && specie != 436;
+    }
+
+    QString getSlotText(const HiddenGrottoState &state)
+    {
+        if (state.getItem())
+        {
+            return QString("%1: %2").arg(state.getSlot()).arg(QString::fromStdString(Translator::getItem(state.getData())));
+        }
+
+        QString specie = QString::fromStdString(Translator::getSpecie(state.getData()));
+        if (!shouldShowSlotGender(state.getData()))
+        {
+            return QString("%1 (%2)").arg(state.getSlot()).arg(specie);
+        }
+
+        return QString("%1 (%2 %3)")
+            .arg(state.getSlot())
+            .arg(specie, QString::fromStdString(Translator::getGender(state.getGender())));
+    }
+}
+
 HiddenGrottoSlotGeneratorModel5::HiddenGrottoSlotGeneratorModel5(QObject *parent) : TableModel(parent)
 {
 }
@@ -47,17 +73,7 @@ QVariant HiddenGrottoSlotGeneratorModel5::data(const QModelIndex &index, int rol
         case 3:
             return state.getGroup();
         case 4:
-            if (state.getItem())
-            {
-                return QString("%1: %2").arg(state.getSlot()).arg(QString::fromStdString(Translator::getItem(state.getData())));
-            }
-            else
-            {
-                return QString("%1 (%2 %3)")
-                    .arg(state.getSlot())
-                    .arg(QString::fromStdString(Translator::getSpecie(state.getData())),
-                         QString::fromStdString(Translator::getGender(state.getGender())));
-            }
+            return getSlotText(state);
         }
     }
     return QVariant();
@@ -109,17 +125,7 @@ QVariant HiddenGrottoSlotSearcherModel5::data(const QModelIndex &index, int role
         case 2:
             return state.getGroup();
         case 3:
-            if (state.getItem())
-            {
-                return QString("%1: %2").arg(state.getSlot()).arg(QString::fromStdString(Translator::getItem(state.getData())));
-            }
-            else
-            {
-                return QString("%1 (%2 %3)")
-                    .arg(state.getSlot())
-                    .arg(QString::fromStdString(Translator::getSpecie(state.getData())),
-                         QString::fromStdString(Translator::getGender(state.getGender())));
-            }
+            return getSlotText(state);
         case 4:
             return state.getAmount();
         case 5:

--- a/Model/Gen5/HiddenGrottoModel.cpp
+++ b/Model/Gen5/HiddenGrottoModel.cpp
@@ -78,7 +78,7 @@ HiddenGrottoSlotSearcherModel5::HiddenGrottoSlotSearcherModel5(QObject *parent) 
 
 int HiddenGrottoSlotSearcherModel5::columnCount(const QModelIndex &parent) const
 {
-    return 7;
+    return 8;
 }
 
 QVariant HiddenGrottoSlotSearcherModel5::data(const QModelIndex &index, int role) const
@@ -93,7 +93,19 @@ QVariant HiddenGrottoSlotSearcherModel5::data(const QModelIndex &index, int role
         case 0:
             return QString::number(display.getInitialSeed(), 16).toUpper().rightJustified(16, '0');
         case 1:
+        {
+            const auto &itemAdvances = state.getItemAdvances();
+            if (!itemAdvances.empty())
+            {
+                QStringList advances;
+                for (u32 advance : itemAdvances)
+                {
+                    advances.append(QString::number(advance));
+                }
+                return advances.join(", ");
+            }
             return state.getAdvances();
+        }
         case 2:
             return state.getGroup();
         case 3:
@@ -109,10 +121,37 @@ QVariant HiddenGrottoSlotSearcherModel5::data(const QModelIndex &index, int role
                          QString::fromStdString(Translator::getGender(state.getGender())));
             }
         case 4:
-            return QString::fromStdString(display.getDateTime().toString());
+            return state.getAmount();
         case 5:
-            return QString::number(display.getTimer0(), 16).toUpper();
+            return QString::fromStdString(display.getDateTime().toString());
         case 6:
+            return QString::number(display.getTimer0(), 16).toUpper();
+        case 7:
+            return QString::fromStdString(Translator::getKeypresses(display.getButtons()));
+        }
+    }
+    else if (role == Qt::UserRole)
+    {
+        const auto &display = model[index.row()];
+        const auto &state = display.getState();
+        int column = index.column();
+        switch (column)
+        {
+        case 0:
+            return static_cast<qulonglong>(display.getInitialSeed());
+        case 1:
+            return state.getAdvances();
+        case 2:
+            return state.getGroup();
+        case 3:
+            return state.getSlot();
+        case 4:
+            return state.getAmount();
+        case 5:
+            return QString::fromStdString(display.getDateTime().toString());
+        case 6:
+            return display.getTimer0();
+        case 7:
             return QString::fromStdString(Translator::getKeypresses(display.getButtons()));
         }
     }

--- a/Model/Gen5/HiddenGrottoModel.hpp
+++ b/Model/Gen5/HiddenGrottoModel.hpp
@@ -139,7 +139,8 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
 private:
-    QStringList header = { tr("Seed"), tr("Advances"), tr("Group"), tr("Slot"), tr("Date/Time"), tr("Timer0"), tr("Buttons") };
+    QStringList header = { tr("Seed"),   tr("Advances"),  tr("Group"), tr("Slot"),
+                           tr("Amount"), tr("Date/Time"), tr("Timer0"), tr("Buttons") };
 };
 
 /**


### PR DESCRIPTION
Makes makes genderless pokemon not display male/female unnecessarily, simplifies the pokemon tabs and lets users search for multiple of the same item to e.g. make PP Max farming easy and quick

<img width="1600" height="860" alt="grafik" src="https://github.com/user-attachments/assets/f16ee05b-42cd-4de6-9c30-95dfb7924dd2" />

<img width="1600" height="860" alt="grafik" src="https://github.com/user-attachments/assets/6cd94cb3-ffbd-4372-92ea-79f993f6fda7" />

