### PR TITLE
Fixed Honey Tree Generator and Searcher

### DIFF
--- a/Form/Controls/CheckList.hpp
+++ b/Form/Controls/CheckList.hpp
@@ -94,14 +94,16 @@ public:
      *
      * @tparam size Size of the array
      *
+     * @param fillTrue Whether to fill the array with true or false
+     *
      * @return Array of true/false to signify which check boxes are checked
      */
     template <size_t size>
-    std::array<bool, size> getCheckedArray() const
+    std::array<bool, size> getCheckedArray(bool fillTrue = true) const
     {
         auto checked = getChecked();
         std::array<bool, size> array;
-        array.fill(true);
+        array.fill(fillTrue);
         std::ranges::copy(checked, array.begin());
         return array;
     }

--- a/Form/Controls/Filter.cpp
+++ b/Form/Controls/Filter.cpp
@@ -277,11 +277,11 @@ bool Filter::getDisableFilters() const
     return ui->checkBoxDisableFilters->isChecked();
 }
 
-std::array<bool, 12> Filter::getEncounterSlots() const
+std::array<bool, 12> Filter::getEncounterSlots(bool fillTrue) const
 {
     // Encounter slot can vary depending on the encounter type, with the highest number being 12 currently
     // Opt to using array of 12 instead of vector for smaller memory usage and avoiding the heap
-    return ui->checkListEncounterSlot->getCheckedArray<12>();
+    return ui->checkListEncounterSlot->getCheckedArray<12>(fillTrue);
 }
 
 u8 Filter::getGender() const

--- a/Form/Controls/Filter.hpp
+++ b/Form/Controls/Filter.hpp
@@ -105,9 +105,11 @@ public:
     /**
      * @brief Gets encounter slots to filter by
      *
+     * @param fillTrue Whether to fill the array with true or false
+     *
      * @return Array of encounter slots
      */
-    std::array<bool, 12> getEncounterSlots() const;
+    std::array<bool, 12> getEncounterSlots(bool fillTrue = true) const;
 
     /**
      * @brief Constructs filter from the UI settings

--- a/Form/Gen4/Wild4.cpp
+++ b/Form/Gen4/Wild4.cpp
@@ -358,7 +358,7 @@ void Wild4::generate()
         else if (encounter == Encounter::HoneyTree)
         {
             method = Method::HoneyTree;
-            std::array<bool, 12> encounters = ui->filterGenerator->getEncounterSlots();
+            std::array<bool, 12> encounters = ui->filterGenerator->getEncounterSlots(false);
             if (std::ranges::count(encounters, true) != 1)
             {
                 QMessageBox msg(QMessageBox::Warning, tr("Too many slots selected"),
@@ -675,7 +675,7 @@ void Wild4::search()
         else if (encounter == Encounter::HoneyTree)
         {
             method = Method::HoneyTree;
-            std::array<bool, 12> encounters = ui->filterSearcher->getEncounterSlots();
+            std::array<bool, 12> encounters = ui->filterSearcher->getEncounterSlots(false);
             if (std::ranges::count(encounters, true) != 1)
             {
                 QMessageBox msg(QMessageBox::Warning, tr("Too many slots selected"),


### PR DESCRIPTION
Because of the way the getCheckedArray function filled the array, it filled any extra slots with "true" which meant the honey tree array, which had 6 entries, and also required 1 encounter to be selected only, would never work. as there would be a minimum of 6, when nothing was selected, or 7 when the expected number was selected. This just simply added a boolean to allow the backfill to be false instead of true optionally, as to prevent breaking changes.